### PR TITLE
Prevent crash when selecting last image + add variable shouldBounce

### DIFF
--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -131,6 +131,12 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var floatRatings: Bool = false
     
+    /**
+     Image should twerk when tap
+     */
+    @IBInspectable public var shouldBounce: Bool = false
+    
+    
     
     // MARK: Initializations
     
@@ -318,18 +324,23 @@ public class HeartRatingView: UIView {
     override public func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         // Update delegate
         if let delegate = self.delegate {
+            
             delegate.heartRatingView(self, didUpdate: self.rating)
             
-            self.fullImageViews[Int(self.rating)].transform = CGAffineTransformMakeScale(0.1, 0.1)
-            
-            UIView.animateWithDuration(2.0,
-                delay: 0,
-                usingSpringWithDamping: 0.2,
-                initialSpringVelocity: 9.0,
-                options: UIViewAnimationOptions.AllowUserInteraction,
-                animations: {
-                    self.fullImageViews[Int(self.rating)].transform = CGAffineTransformIdentity
-                }, completion: nil)
+            //Check if tapped image can bounce
+            if shouldBounce {
+                let imageViewIndex = self.rating - 1 <= 0 ? 0 : self.rating - 1
+                self.fullImageViews[Int(imageViewIndex)].transform = CGAffineTransformMakeScale(0.1, 0.1)
+                
+                UIView.animateWithDuration(2.0,
+                    delay: 0,
+                    usingSpringWithDamping: 0.2,
+                    initialSpringVelocity: 9.0,
+                    options: UIViewAnimationOptions.AllowUserInteraction,
+                    animations: {
+                        self.fullImageViews[Int(imageViewIndex)].transform = CGAffineTransformIdentity
+                    }, completion: nil)
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

Historical closed pull request: Prevent crash when selecting last image + add variable shouldBounce

### Original Description

Hi !
A added a little check to prevent a crash when user select last rating.
- Added a shouldbounce property

Cheers

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
