### PR TITLE
Add flag controlling if empty image view should be hidden during bounce

### DIFF
--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -136,6 +136,11 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var shouldBounce: Bool = false
     
+    /**
+     Empty view should be hidden during bounce
+     */
+    @IBInspectable public var shouldHideEmptyViewDuringBounce: Bool = false
+    
     
     
     // MARK: Initializations
@@ -329,8 +334,13 @@ public class HeartRatingView: UIView {
             
             //Check if tapped image can bounce
             if shouldBounce {
-                let imageViewIndex = self.rating - 1 <= 0 ? 0 : self.rating - 1
-                self.fullImageViews[Int(imageViewIndex)].transform = CGAffineTransformMakeScale(0.1, 0.1)
+                let imageViewIndex = Int(self.rating - 1 <= 0 ? 0 : self.rating - 1)
+                self.fullImageViews[imageViewIndex].transform = CGAffineTransformMakeScale(0.1, 0.1)
+                
+                let originalEmptyViewHiddenFlagValue = self.emptyImageViews[imageViewIndex].hidden
+                if shouldHideEmptyViewDuringBounce {
+                    self.emptyImageViews[imageViewIndex].hidden = true
+                }
                 
                 UIView.animateWithDuration(2.0,
                     delay: 0,
@@ -338,8 +348,10 @@ public class HeartRatingView: UIView {
                     initialSpringVelocity: 9.0,
                     options: UIViewAnimationOptions.AllowUserInteraction,
                     animations: {
-                        self.fullImageViews[Int(imageViewIndex)].transform = CGAffineTransformIdentity
-                    }, completion: nil)
+                        self.fullImageViews[imageViewIndex].transform = CGAffineTransformIdentity
+                }) { _ in
+                    self.emptyImageViews[imageViewIndex].hidden = originalEmptyViewHiddenFlagValue
+                }
             }
         }
     }

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -184,6 +184,16 @@ public class HeartRatingView: UIView {
                 imageView.hidden = true
             }
         }
+        
+        //also reset empty image views (as they may be hidden during a bounce animation)
+        for i in 0..<self.emptyImageViews.count {
+            
+            //only reset empty views above the current rating (the current value will be hidden when bounce animation finishes)
+            let indexAsFloat = Float(i + 1)
+            if self.rating < indexAsFloat {
+                self.emptyImageViews[i].hidden = false
+            }
+        }
     }
     
     // MARK: Layout helper classes


### PR DESCRIPTION
## Summary

Historical closed pull request: Add flag controlling if empty image view should be hidden during bounce

### Original Description

Currently in our designs we have an empty state which is a star with an outline, and a full state which is the filled in star. The bounce animation looks great, but shows the border of the star so loses some impact: this change adds a flag which will hide the empty image view corresponding to the bouncing full view for the duration of the bounce

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
