### PR TITLE
ci: prevent checkout credential persistence

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,5 +19,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Validate projects and rating baseline
         run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+## Repository purpose
+
+`garethpaul/iHeartRating` is an Apple platform application or Swift sample. Simple Ratings View for iOS enabling you to use any image as a rating e.g. hearts, stars, pigeons etc.
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+- `iHeartRating.xcodeproj` - Xcode project
+- `assets` - repository source or sample assets
+- `example` - repository source or sample assets
+- `iHeartRating` - repository source or sample assets
+- `iHeartRatingTests` - repository source or sample assets
+- `screenshots` - repository source or sample assets
+
+## Development commands
+
+- Install dependencies: no repository-specific install command is documented.
+- Full baseline: `make check`
+- Local Apple development: `open iHeartRating.xcodeproj`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Language mix noted in the README: Swift (6), C/C++ headers (1), shell (1).
+- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+
+## Testing guidance
+
+- Test-related files detected: `example/SampleApp/SampleAppTests/SampleAppTests.swift`, `example/SampleApp/SampleAppUITests/SampleAppUITests.swift`, `iHeartRating.podspec`, `iHeartRating.xcodeproj/xcshareddata/xcschemes/iHeartRatingTests.xcscheme`, `iHeartRating/0.1.6/iHeartRating.podspec`, `iHeartRatingTests/iHeartRatingTests.swift`
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
+- UI configuration changes should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, or out-of-range ratings.
+- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- See `SECURITY.md` for vulnerability reporting and safe research guidance.
+- See `VISION.md` for project direction and contribution guardrails.
+- See `docs/plans/2026-06-08-bounce-without-delegate.md` for the bounce-without-delegate guardrail.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 - Normalized NaN rating assignments to `minRating` before rendering or bounce
   index conversion.
-- Added pinned, read-only macOS CI for the canonical `make check` baseline.
+- Added pinned, read-only macOS CI without persisted checkout credentials for
+  the canonical `make check` baseline.
 - Made Xcode-enabled checks parse both the library and SampleApp projects while
   keeping full Swift 2 compilation tied to a compatible legacy toolchain.
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ image changes recalculate frames before masks refresh.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 
-The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
-available, the baseline parses both `iHeartRating.xcodeproj` and the SampleApp
-project with `xcodebuild -list`. This verifies project-file integrity but does
-not claim that Swift 2 sources compile on a current Xcode toolchain.
+The pinned, credential-free GitHub Actions check runs `make check` on
+`macos-15`. When Xcode is available, the baseline parses both
+`iHeartRating.xcodeproj` and the SampleApp project with `xcodebuild -list`.
+This verifies project-file integrity but does not claim that Swift 2 sources
+compile on a current Xcode toolchain.
 
 For full legacy verification, use Xcode 7.3 with its matching simulator runtime
 and run Xcode's test action, `xcodebuild test`, or `./build.sh`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,9 +30,9 @@ Helpful reports include:
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - `make check` runs a static baseline for malformed configuration hardening, CocoaPods metadata, plist/storyboard parsing, build-script syntax, rating bounds, and rating-view edge cases when Xcode is unavailable.
-- The pinned macOS workflow uses read-only repository permissions and parses
-  both Xcode projects without credentials, signing material, or package
-  publication access.
+- The pinned macOS workflow uses read-only repository permissions, disables
+  checkout credential persistence, and parses both Xcode projects without
+  signing material or package publication access.
 - Rating controls should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, out-of-range ratings, non-editable touch endings, empty touch endings, or unexpected image assets.
 - NaN ratings must be normalized before mask calculations or integer conversion
   for bounce animation indexing.

--- a/VISION.md
+++ b/VISION.md
@@ -28,8 +28,8 @@ Priority:
 - Normalize NaN rating assignments before rendering and animation indexing
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
-- Keep pinned macOS CI parsing both Xcode projects through the canonical
-  `make check` gate
+- Keep pinned, credential-free macOS CI parsing both Xcode projects through the
+  canonical `make check` gate
 
 Next priorities:
 

--- a/docs/plans/2026-06-10-hosted-project-validation.md
+++ b/docs/plans/2026-06-10-hosted-project-validation.md
@@ -11,7 +11,8 @@ current hosted project-file check.
 
 ## Completed Scope
 
-- Added a pinned GitHub Actions workflow with read-only repository permissions.
+- Added a pinned GitHub Actions workflow with read-only repository permissions
+  and disabled checkout credential persistence.
 - Runs the canonical `make check` gate on a bounded `macos-15` job.
 - Parses both the library and SampleApp Xcode projects when Xcode is available.
 - Kept full Swift 2 compilation and simulator testing tied to Xcode 7.3 and its

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -298,16 +298,19 @@ def main():
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
             failures)
-    require("permissions:\n  contents: read" in workflow,
-            "Check workflow must use read-only repository permissions",
+    require(workflow.count("permissions:\n  contents: read") == 1 and
+            not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and
+            not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", workflow),
+            "Check workflow must use one top-level read-only permissions block",
             failures)
     require("cancel-in-progress: true" in workflow and "runs-on: macos-15" in workflow and
             "timeout-minutes: 10" in workflow,
             "Check workflow must bound duplicate and long-running macOS jobs",
             failures)
-    require("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow and
+    require(workflow.count("uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10") == 1 and
+            "persist-credentials: false" in workflow and
             "run: make check" in workflow,
-            "Check workflow must pin checkout and run the canonical baseline",
+            "Check workflow must pin one credential-free checkout and run the canonical baseline",
             failures)
 
     if shutil.which("xcodebuild"):


### PR DESCRIPTION
## Summary

Historical closed pull request: ci: prevent checkout credential persistence

### Original Description

### Summary

The macOS validation job no longer leaves its GitHub token in the checkout configuration. The baseline now requires one immutable checkout action, one top-level read-only permissions block, and disabled credential persistence while still allowing harmless workflow extensions.

Repository guidance also records the legacy Swift/Xcode constraints and the rating-view edge cases that must remain protected. This keeps future changes aligned with the existing NaN, bounds, touch, image-layout, and delegate safety contracts without claiming current-Xcode compilation support.

### Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- Python checker compilation
- Workflow, plist, project, and storyboard metadata parsing
- POSIX shell syntax check for `build.sh`
- Seven hostile mutations rejected and one harmless workflow extension accepted
- Conflict-marker, secret, and `git diff --check` scans

Local validation ran without Xcode or CocoaPods. Hosted macOS validation is the authoritative check that both Xcode projects parse at the pushed head.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
