### PR TITLE
fix: lay out rating images in local bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@
 
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - UI configuration changes should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, or out-of-range ratings.
+- Keep rating image layout in local bounds coordinates so transforms do not
+  distort child geometry.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   the canonical `make check` baseline.
 - Made Xcode-enabled checks parse both the library and SampleApp projects while
   keeping full Swift 2 compilation tied to a compatible legacy toolchain.
+- Calculated rating image geometry from local bounds so view transforms do not
+  distort child layout.
 
 ## 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ It also keeps non-editable began/moved touch events from sending live-update
 delegate callbacks.
 It also keeps image layout invalidation in the rating image setters so runtime
 image changes recalculate frames before masks refresh.
+Rating image geometry is calculated from the view's local bounds so transforms
+do not inflate or misalign child images.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 
@@ -104,6 +106,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - UI configuration changes should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, or out-of-range ratings.
 - Runtime image changes should preserve image layout invalidation before mask
   refresh work runs.
+- Rating image layout should use local bounds rather than transformed frame
+  dimensions.
 
 ## Maintenance Notes
 
@@ -122,6 +126,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   image layout invalidation guardrail.
 - See `docs/plans/2026-06-10-nan-rating-boundary.md` for non-finite rating
   normalization.
+- See `docs/plans/2026-06-12-bounds-based-image-layout.md` for transformed-view
+  layout correctness.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, podspecs, plist/storyboard files, or build scripts.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,8 @@ Helpful reports include:
 - NaN ratings must be normalized before mask calculations or integer conversion
   for bounce animation indexing.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
+- Transformed rating views should calculate child geometry from local bounds,
+  avoiding oversized or misaligned interactive regions.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,7 @@ Priority:
   project files, non-editable began/moved touch handling, and build-script
   syntax
 - Keep image layout invalidation tied to runtime rating image changes
+- Keep child image geometry in the rating view's local bounds coordinate space
 - Normalize NaN rating assignments before rendering and animation indexing
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
@@ -65,6 +66,8 @@ delegate work. Non-editable began/moved touch events should also ignore
 live-update delegate work.
 Image layout invalidation should run when rating images change so masks refresh
 against current frames.
+Scaled or rotated rating views should continue laying out child images from
+local bounds rather than transformed frame dimensions.
 On macOS, the baseline should also parse both Xcode projects. Full Swift 2
 compilation and simulator testing remain tied to Xcode 7.3 and a compatible
 runtime.

--- a/docs/plans/2026-06-12-bounds-based-image-layout.md
+++ b/docs/plans/2026-06-12-bounds-based-image-layout.md
@@ -1,0 +1,29 @@
+# Bounds-Based Rating Image Layout
+
+status: planned
+
+## Context
+
+`layoutSubviews()` calculates child image sizes and spacing from the rating
+view's `frame`. A view's frame is expressed in its superview's coordinate space
+and changes when transforms are applied, while subview layout belongs in the
+view's local `bounds` coordinate space. Scaled or rotated rating views can
+therefore lay out hearts using transformed dimensions and produce oversized or
+misaligned content.
+
+## Scope
+
+- Calculate image width, height, spacing, and origin from `bounds`.
+- Preserve existing minimum image size and single-image safeguards.
+- Add XCTest coverage for a scaled rating view whose frame and bounds differ.
+- Extend the dependency-free baseline so frame-based layout regressions fail
+  even when a compatible Swift 2 toolchain is unavailable.
+- Document the local-coordinate layout invariant.
+
+## Verification
+
+- `make check`
+- `bash -n build.sh`
+- `git diff --check`
+- A mutation that restores `frame`-based image sizing must fail the baseline.
+- Hosted macOS validation must parse both Xcode projects.

--- a/docs/plans/2026-06-12-bounds-based-image-layout.md
+++ b/docs/plans/2026-06-12-bounds-based-image-layout.md
@@ -1,6 +1,6 @@
 # Bounds-Based Rating Image Layout
 
-status: planned
+status: completed
 
 ## Context
 
@@ -11,7 +11,7 @@ view's local `bounds` coordinate space. Scaled or rotated rating views can
 therefore lay out hearts using transformed dimensions and produce oversized or
 misaligned content.
 
-## Scope
+## Completed Scope
 
 - Calculate image width, height, spacing, and origin from `bounds`.
 - Preserve existing minimum image size and single-image safeguards.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -250,15 +250,21 @@ public class HeartRatingView: UIView {
                 return
             }
 
-            let desiredImageWidth = self.frame.size.width / CGFloat(imageCount)
+            let layoutBounds = self.bounds
+            let desiredImageWidth = layoutBounds.size.width / CGFloat(imageCount)
             let maxImageWidth = max(self.minImageSize.width, desiredImageWidth)
-            let maxImageHeight = max(self.minImageSize.height, self.frame.size.height)
+            let maxImageHeight = max(self.minImageSize.height, layoutBounds.size.height)
             let imageViewSize = self.sizeForImage(emptyImage, inSize: CGSizeMake(maxImageWidth, maxImageHeight))
             let imageXOffset = imageCount > 1 ?
-                (self.frame.size.width - (imageViewSize.width * CGFloat(imageCount))) / CGFloat(imageCount - 1) : 0
+                (layoutBounds.size.width - (imageViewSize.width * CGFloat(imageCount))) / CGFloat(imageCount - 1) : 0
             
             for i in 0..<imageCount {
-                let imageFrame = CGRectMake(i==0 ? 0:CGFloat(i)*(imageXOffset+imageViewSize.width), 0, imageViewSize.width, imageViewSize.height)
+                let imageFrame = CGRectMake(
+                    layoutBounds.origin.x + (i == 0 ? 0 : CGFloat(i) * (imageXOffset + imageViewSize.width)),
+                    layoutBounds.origin.y,
+                    imageViewSize.width,
+                    imageViewSize.height
+                )
                 
                 var imageView = self.emptyImageViews[i]
                 imageView.frame = imageFrame

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -86,6 +86,22 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(hrv.minImageSize.height == 0)
     }
 
+    func testLayoutUsesLocalBoundsWhenViewIsScaled() {
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        hrv.emptyImage = image
+        hrv.transform = CGAffineTransformMakeScale(2, 2)
+        hrv.layoutSubviews()
+
+        let firstImageView = hrv.subviews.first as! UIImageView
+        XCTAssert(hrv.frame.size.width == 200)
+        XCTAssert(hrv.bounds.size.width == 100)
+        XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
+    }
+
     func testTouchesEndedDoesNotNotifyWhenNotEditable() {
         let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
         let delegate = RecordingHeartRatingDelegate()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -21,6 +21,7 @@ NONEDITABLE_TOUCH_PHASE_PLAN = ROOT / "docs/plans/2026-06-09-noneditable-touch-p
 IMAGE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-09-rating-image-layout-invalidation.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
+BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 
 
 def require(condition, message, failures):
@@ -102,6 +103,7 @@ def main():
         "docs/plans/2026-06-09-rating-image-layout-invalidation.md",
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-nan-rating-boundary.md",
+        "docs/plans/2026-06-12-bounds-based-image-layout.md",
     ]
 
     for relative_path in required_files:
@@ -173,6 +175,16 @@ def main():
     require("imageCount > 1 ?" in rating_view,
             "layoutSubviews must avoid dividing by imageCount - 1 for single-rating views",
             failures)
+    require("let layoutBounds = self.bounds" in rating_view and
+            "layoutBounds.size.width / CGFloat(imageCount)" in rating_view and
+            "max(self.minImageSize.height, layoutBounds.size.height)" in rating_view and
+            "layoutBounds.origin.x" in rating_view and "layoutBounds.origin.y" in rating_view,
+            "layoutSubviews must calculate image geometry in local bounds coordinates",
+            failures)
+    require("self.frame.size.width / CGFloat(imageCount)" not in rating_view and
+            "max(self.minImageSize.height, self.frame.size.height)" not in rating_view,
+            "layoutSubviews must not size child images from transformed frame coordinates",
+            failures)
     require("if self.emptyImageViews.isEmpty" in rating_view,
             "touch handling must guard empty image arrays",
             failures)
@@ -198,6 +210,9 @@ def main():
             "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
             "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
+            "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
+            "CGAffineTransformMakeScale(2, 2)" in tests and
+            "hrv.bounds.size.width == 100" in tests and
             "testTouchesEndedDoesNotNotifyWhenNotEditable" in tests and
             "testTouchesEndedDoesNotNotifyWithoutTouches" in tests and
             "testTouchesBeganDoesNotNotifyWithoutTouches" in tests and
@@ -237,11 +252,12 @@ def main():
     image_layout_plan = IMAGE_LAYOUT_PLAN.read_text(encoding="utf-8") if IMAGE_LAYOUT_PLAN.exists() else ""
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
+    bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
             failures)
-    require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "podspec" in readme and "delegate-independent bounce" in readme and "non-editable" in readme and "empty touch" in readme.lower() and "minImageSize" in readme and "image layout invalidation" in readme,
+    require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "podspec" in readme and "delegate-independent bounce" in readme and "non-editable" in readme and "empty touch" in readme.lower() and "minImageSize" in readme and "image layout invalidation" in readme and "local bounds" in readme.lower(),
             "README must document static verification, build script, and podspec expectations",
             failures)
     require("empty began/moved touch" in readme,
@@ -250,16 +266,16 @@ def main():
     require("non-editable began/moved touch" in readme,
             "README must document non-editable began/moved touch guards",
             failures)
-    require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision,
+    require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
             failures)
     require("non-editable began/moved touch" in vision,
             "VISION must describe non-editable began/moved touch guards",
             failures)
-    require("malformed configuration" in security and "make check" in security and "non-editable" in security and "empty touch" in security.lower() and "minImageSize" in security and "image layout invalidation" in security,
+    require("malformed configuration" in security and "make check" in security and "non-editable" in security and "empty touch" in security.lower() and "minImageSize" in security and "image layout invalidation" in security and "local bounds" in security.lower(),
             "SECURITY must document configuration hardening and verification",
             failures)
-    require("zero-size" in changes and "maxRating" in changes and "podspec" in changes and "rating bounds" in changes and "bounce" in changes and "not editable" in changes and "empty touch" in changes.lower() and "minImageSize" in changes and "image layout invalidation" in changes and "make lint" in changes and "make test" in changes and "make build" in changes,
+    require("zero-size" in changes and "maxRating" in changes and "podspec" in changes and "rating bounds" in changes and "bounce" in changes and "not editable" in changes and "empty touch" in changes.lower() and "minImageSize" in changes and "image layout invalidation" in changes and "local bounds" in changes.lower() and "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record rating edge-case, rating bounds, and podspec updates",
             failures)
     require("empty began/moved touch" in changes,
@@ -297,6 +313,9 @@ def main():
             failures)
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
+            failures)
+    require("status: completed" in bounds_layout_plan and "frame-based" in bounds_layout_plan,
+            "bounds-based image layout plan must record completed mutation verification",
             failures)
     require(workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: lay out rating images in local bounds

### Original Description

### Summary

- calculate rating image size, spacing, and origin from local `bounds`
- keep transformed `frame` dimensions out of subview layout
- add a scaled-view XCTest and static regression contract
- document the local-coordinate layout invariant

## Verification

- `make lint`
- `make test`
- `make build`
- `make check`
- `bash -n build.sh`
- `git diff --check`
- frame-based layout mutation rejected

## Toolchain note

The project remains a legacy Swift 2/Xcode 7.3 sample. Local `xcodebuild` is unavailable, and current hosted Xcode can parse the projects but cannot compile Swift 2; the source behavior is therefore protected by the checked-in XCTest and static baseline.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
