### PR TITLE
docs: record bounds layout verification

### DIFF
--- a/docs/plans/2026-06-12-bounds-based-image-layout.md
+++ b/docs/plans/2026-06-12-bounds-based-image-layout.md
@@ -27,3 +27,25 @@ misaligned content.
 - `git diff --check`
 - A mutation that restores `frame`-based image sizing must fail the baseline.
 - Hosted macOS validation must parse both Xcode projects.
+
+## Work Completed
+
+- Changed child image sizing, spacing, and origin calculations to use the
+  rating view's local `bounds` coordinate space.
+- Preserved minimum image sizing, the single-image path, parser behavior,
+  touch handling, and package metadata.
+- Added transformed-view XCTest coverage and a dependency-free static contract
+  rejecting frame-based layout regressions.
+
+## Verification Completed
+
+- All four Make gates, checker compilation, `bash -n build.sh`, and
+  `git diff --check` passed locally; Xcode project parsing was truthfully
+  skipped because Xcode is unavailable in the local environment.
+- Implementation push run `27394309114` and pull-request run `27394315070`
+  passed at commit `542646ef0f910afe803638be316194d4995654b7`; the hosted macOS
+  gate parsed both Xcode projects and ran the rating baseline.
+- Post-merge push run `27394330649` and CodeQL setup run `27402322718` passed
+  at default-branch merge commit `7077f27aeed5950d99fc4944ac436d007136f193`.
+- A mutation restoring `frame`-based image sizing was rejected by the
+  baseline.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -314,8 +314,25 @@ def main():
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
             failures)
-    require("status: completed" in bounds_layout_plan and "frame-based" in bounds_layout_plan,
-            "bounds-based image layout plan must record completed mutation verification",
+    bounds_layout_statuses = re.findall(
+        r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
+    )
+    bounds_layout_sections = bounds_layout_plan.split("## Verification Completed\n", 1)
+    bounds_layout_verification = (
+        bounds_layout_sections[1] if len(bounds_layout_sections) == 2 else ""
+    )
+    bounds_layout_required_evidence = (
+        "All four Make gates",
+        "push run `27394309114`",
+        "pull-request run `27394315070`",
+        "push run `27394330649`",
+        "CodeQL setup run `27402322718`",
+        "mutation restoring `frame`-based image sizing",
+    )
+    require(bounds_layout_statuses == ["status: completed"]
+            and all(item in bounds_layout_verification for item in bounds_layout_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b", bounds_layout_verification, re.IGNORECASE) is None,
+            "bounds-based image layout plan must record completed status and actual verification",
             failures)
     require(workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and


### PR DESCRIPTION
## Summary

- record the completed bounds-based image layout change with exact local and hosted evidence
- distinguish local static validation from hosted Xcode project parsing
- require section-specific completed verification and canonical run IDs

## Baseline

The pre-change constraints and motivation are captured in the Summary and existing supporting sections.

## Improvements

The implemented changes are captured in the Summary and existing supporting sections.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `bash -n build.sh`
- `git diff --check`
- four hostile mutations rejected: stale status, placeholder evidence, falsified run ID, and restored frame-space layout

## Risk

Documentation and baseline-checker only. Rating behavior, package metadata, deployment targets, and Xcode projects are unchanged.

## Follow-Ups

No additional follow-up is introduced by this description-only normalization; existing monitoring and remaining-work notes remain authoritative.
