### PR TITLE
Hide ratings for incomplete image pairs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Made incomplete image pair configuration hide full rating overlays and clear
+  stale masks until both images are configured again.
+
 ## 2026-06-10
 
 - Normalized NaN rating assignments to `minRating` before rendering or bounce

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ It also keeps image layout invalidation in the rating image setters so runtime
 image changes recalculate frames before masks refresh.
 Rating image geometry is calculated from the view's local bounds so transforms
 do not inflate or misalign child images.
+An incomplete image pair renders no full overlays: clearing either image hides
+filled ratings and removes stale masks until both images are configured again.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 
@@ -108,6 +110,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   refresh work runs.
 - Rating image layout should use local bounds rather than transformed frame
   dimensions.
+- An incomplete image pair should hide full overlays and clear stale masks
+  until both rating images are configured.
 
 ## Maintenance Notes
 
@@ -128,6 +132,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   normalization.
 - See `docs/plans/2026-06-12-bounds-based-image-layout.md` for transformed-view
   layout correctness.
+- See `docs/plans/2026-06-13-incomplete-image-pair.md` for fail-closed image-pair
+  rendering.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, podspecs, plist/storyboard files, or build scripts.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.
+- An incomplete image pair should hide full overlays and remove stale masks
+  rather than displaying a rating without its empty-image baseline.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
   syntax
 - Keep image layout invalidation tied to runtime rating image changes
 - Keep child image geometry in the rating view's local bounds coordinate space
+- Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
@@ -68,6 +69,8 @@ Image layout invalidation should run when rating images change so masks refresh
 against current frames.
 Scaled or rotated rating views should continue laying out child images from
 local bounds rather than transformed frame dimensions.
+An incomplete image pair should render without full overlays or stale masks,
+then restore normal rating rendering when both images are configured.
 On macOS, the baseline should also parse both Xcode projects. Full Swift 2
 compilation and simulator testing remain tied to Xcode 7.3 and a compatible
 runtime.

--- a/docs/plans/2026-06-13-incomplete-image-pair.md
+++ b/docs/plans/2026-06-13-incomplete-image-pair.md
@@ -1,6 +1,6 @@
 # Incomplete Rating Image Pair
 
-status: planned
+status: completed
 
 ## Context
 
@@ -68,3 +68,17 @@ stored rating or rebuilding image views.
 - `git diff --check`
 - Hostile mutations removing the nil guard, mask cleanup, early return,
   regression test, plan status, or verification evidence must be rejected.
+
+## Verification Completed
+
+- All four Make gates (`make lint`, `make test`, `make build`, and
+  `make check`) passed against the completed implementation and plan.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, both
+  `ruby -c` podspec checks, and `git diff --check` passed.
+- A prepared baseline passed and eight hostile mutations were rejected. The
+  mutations removed either side of the nil guard, mask cleanup, overlay hiding,
+  the early return, the regression test, the stale-mask assertion, or completed
+  plan status or required verification evidence.
+- `xcodebuild` was unavailable on this Linux host, so the legacy Swift 2 XCTest
+  suite was not executed locally. The canonical baseline reported the static
+  iOS-only limitation rather than claiming simulator coverage.

--- a/docs/plans/2026-06-13-incomplete-image-pair.md
+++ b/docs/plans/2026-06-13-incomplete-image-pair.md
@@ -1,0 +1,70 @@
+# Incomplete Rating Image Pair
+
+status: planned
+
+## Context
+
+`HeartRatingView` overlays full images on empty images. When `emptyImage` is
+cleared after layout, its image views become empty but `refresh()` can leave the
+previous full overlays visible according to the current rating.
+
+The control can therefore display a rating without its configured empty-image
+baseline, even though layout depends on that image pair.
+
+## Priority
+
+Image configuration is public and mutable. An incomplete pair should render no
+filled rating rather than stale or misleading overlays, without changing the
+stored rating or rebuilding image views.
+
+## Requirements
+
+- R1. `refresh()` must hide every full image view when either `emptyImage` or
+  `fullImage` is nil.
+- R2. Hidden full image views must have stale masks removed.
+- R3. Completing the image pair must restore normal whole, half, and floating
+  rating rendering through the existing refresh path.
+- R4. Rating values, image-view counts, layout math, bounce behavior, and
+  delegate callbacks must remain unchanged.
+- R5. Add XCTest coverage for clearing and restoring the image pair plus a
+  static early-return contract.
+
+## Implementation Units
+
+### U1. Fail closed for incomplete images
+
+- **Files:** `iHeartRating/iHeartRatingView.swift`
+- Add an early refresh boundary that clears masks, hides full overlays, and
+  returns before rating-based visibility logic.
+
+### U2. Extend regression coverage
+
+- **Files:** `iHeartRatingTests/iHeartRatingTests.swift`,
+  `scripts/check-baseline.py`
+- Prove overlay hiding after image removal and restoration after reconfiguration.
+
+### U3. Document the rendering boundary
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record deterministic rendering for incomplete image configuration.
+
+## Scope Boundaries
+
+- Do not change the public rating API, image layout, touch math, or animation.
+- Do not modernize Swift, Xcode, deployment targets, podspec versions, or the
+  example app.
+- Do not claim local simulator execution when Xcode is unavailable.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations removing the nil guard, mask cleanup, early return,
+  regression test, plan status, or verification evidence must be rejected.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -189,6 +189,14 @@ public class HeartRatingView: UIView {
     }
     
     func refresh() {
+        if self.emptyImage == nil || self.fullImage == nil {
+            for imageView in self.fullImageViews {
+                imageView.layer.mask = nil
+                imageView.hidden = true
+            }
+            return
+        }
+
         for i in 0..<self.fullImageViews.count {
             let imageView = self.fullImageViews[i]
             

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -102,6 +102,31 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
     }
 
+    func testIncompleteImagePairHidesAndRestoresFullImages() {
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        hrv.emptyImage = image
+        hrv.fullImage = image
+        hrv.rating = 0.5
+        hrv.layoutSubviews()
+
+        let firstFullImageView = hrv.subviews[1] as! UIImageView
+        XCTAssertFalse(firstFullImageView.hidden)
+        XCTAssertNotNil(firstFullImageView.layer.mask)
+
+        hrv.emptyImage = nil
+        XCTAssertTrue(firstFullImageView.hidden)
+        XCTAssertNil(firstFullImageView.layer.mask)
+
+        hrv.emptyImage = image
+        hrv.layoutSubviews()
+        XCTAssertFalse(firstFullImageView.hidden)
+        XCTAssertNotNil(firstFullImageView.layer.mask)
+    }
+
     func testTouchesEndedDoesNotNotifyWhenNotEditable() {
         let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
         let delegate = RecordingHeartRatingDelegate()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -22,6 +22,7 @@ IMAGE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-09-rating-image-layout-invalidati
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
+INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 
 
 def require(condition, message, failures):
@@ -104,6 +105,7 @@ def main():
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-nan-rating-boundary.md",
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
+        "docs/plans/2026-06-13-incomplete-image-pair.md",
     ]
 
     for relative_path in required_files:
@@ -137,6 +139,12 @@ def main():
 
     rating_view = read("iHeartRating/iHeartRatingView.swift")
     tests = read("iHeartRatingTests/iHeartRatingTests.swift")
+    refresh_body = rating_view.split("func refresh() {", 1)[1].split("// MARK: Layout helper classes", 1)[0]
+    incomplete_image_branch = re.search(
+        r"if self\.emptyImage == nil \|\| self\.fullImage == nil \{(?P<body>.*?)\n\s*return\s*\n\s*\}",
+        refresh_body,
+        re.DOTALL,
+    )
     require(rating_view.count("let maxImageWidth =") == 1,
             "layoutSubviews must declare maxImageWidth once",
             failures)
@@ -206,11 +214,21 @@ def main():
     require(rating_view.count("if touches.isEmpty") >= 3,
             "touchesBegan, touchesMoved, and touchesEnded must all guard empty touch sets",
             failures)
+    require(incomplete_image_branch is not None and
+            "for imageView in self.fullImageViews" in incomplete_image_branch.group("body") and
+            "imageView.layer.mask = nil" in incomplete_image_branch.group("body") and
+            "imageView.hidden = true" in incomplete_image_branch.group("body"),
+            "refresh must clear and hide full overlays before returning for an incomplete image pair",
+            failures)
     require("testMaxRatingDoesNotStayBelowOne" in tests and "testZeroSizeImageReturnsZeroSize" in tests and
             "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
             "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
+            "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
+            "XCTAssertTrue(firstFullImageView.hidden)" in tests and
+            "XCTAssertNil(firstFullImageView.layer.mask)" in tests and
+            tests.count("XCTAssertFalse(firstFullImageView.hidden)") == 2 and
             "CGAffineTransformMakeScale(2, 2)" in tests and
             "hrv.bounds.size.width == 100" in tests and
             "testTouchesEndedDoesNotNotifyWhenNotEditable" in tests and
@@ -253,6 +271,7 @@ def main():
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
+    incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -266,14 +285,23 @@ def main():
     require("non-editable began/moved touch" in readme,
             "README must document non-editable began/moved touch guards",
             failures)
+    require("incomplete image pair" in readme.lower(),
+            "README must document fail-closed rendering for incomplete image pairs",
+            failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
             failures)
     require("non-editable began/moved touch" in vision,
             "VISION must describe non-editable began/moved touch guards",
             failures)
+    require("incomplete image pair" in vision.lower(),
+            "VISION must describe fail-closed rendering for incomplete image pairs",
+            failures)
     require("malformed configuration" in security and "make check" in security and "non-editable" in security and "empty touch" in security.lower() and "minImageSize" in security and "image layout invalidation" in security and "local bounds" in security.lower(),
             "SECURITY must document configuration hardening and verification",
+            failures)
+    require("incomplete image pair" in security.lower(),
+            "SECURITY must document incomplete image-pair hardening",
             failures)
     require("zero-size" in changes and "maxRating" in changes and "podspec" in changes and "rating bounds" in changes and "bounce" in changes and "not editable" in changes and "empty touch" in changes.lower() and "minImageSize" in changes and "image layout invalidation" in changes and "local bounds" in changes.lower() and "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record rating edge-case, rating bounds, and podspec updates",
@@ -283,6 +311,9 @@ def main():
             failures)
     require("non-editable began/moved touch" in changes,
             "CHANGES must record non-editable began/moved touch guards",
+            failures)
+    require("incomplete image pair" in changes.lower(),
+            "CHANGES must record incomplete image-pair rendering behavior",
             failures)
     require("status: completed" in baseline_plan and "status: completed" in rating_bounds_plan and "status: completed" in bounce_plan,
             "plans must be marked completed",
@@ -313,6 +344,11 @@ def main():
             failures)
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
+            failures)
+    require("status: completed" in incomplete_image_plan and
+            "All four Make gates" in incomplete_image_plan and
+            "hostile mutations" in incomplete_image_plan.lower(),
+            "incomplete image pair plan must record completed status and actual verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary
Hide filled rating overlays whenever either configured image is missing, then restore normal rendering when the pair is complete.

## Baseline
Clearing `emptyImage` after layout could leave the prior full overlays visible because `refresh()` applied rating visibility without checking whether both rendering images remained configured.

## Improvements
- fail closed for incomplete image pairs
- clear stale partial-rating masks before returning
- add XCTest intent, branch-scoped static contracts, documentation, and completed plan evidence

## Validation
- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- both podspec syntax checks
- `git diff --check`
- prepared baseline plus eight rejected hostile mutations

## Risk
`xcodebuild` is unavailable on the Linux validation host, so local simulator and legacy Swift 2 XCTest execution were not claimed. Hosted project parsing does not replace interactive rendering verification.

## Follow-Ups
This PR is stacked on #13 and should be retargeted to `master` after #13 merges. Swift and project modernization remain separate.