### PR TITLE
fix: normalize NaN minimum image sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Normalized NaN `minImageSize` width and height independently to zero while
+  preserving valid companion dimensions.
 - Made incomplete image pair configuration hide full rating overlays and clear
   stale masks until both images are configured again.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ An incomplete image pair renders no full overlays: clearing either image hides
 filled ratings and removes stale masks until both images are configured again.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
+NaN `minImageSize` dimensions normalize independently to zero while valid
+companion dimensions are preserved.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,8 @@ Helpful reports include:
 - Rating controls should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, out-of-range ratings, non-editable touch endings, empty touch endings, or unexpected image assets.
 - NaN ratings must be normalized before mask calculations or integer conversion
   for bounce animation indexing.
+- NaN `minImageSize` dimensions must normalize to zero before layout geometry is
+  calculated.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Keep child image geometry in the rating view's local bounds coordinate space
 - Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
+- Normalize NaN `minImageSize` dimensions before image layout
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/docs/plans/2026-06-13-nan-min-image-size.md
+++ b/docs/plans/2026-06-13-nan-min-image-size.md
@@ -1,6 +1,6 @@
 # Normalize NaN Minimum Image Sizes
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,8 +40,25 @@ through layout `max(...)`, aspect sizing, and child image frames.
 
 ## Work Completed
 
-Pending implementation.
+- Normalized NaN width and height values independently to zero in the
+  `minImageSize` setter.
+- Preserved each valid companion dimension and the existing negative-value
+  clamp.
+- Added hosted XCTest cases for NaN width and NaN height assignments.
+- Extended static contracts and configuration documentation without changing
+  rating, touch, project, podspec, or workflow behavior.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`,
+  `ruby -c iHeartRating.podspec`, and `git diff --check` passed.
+- Five isolated hostile mutations were rejected: removed width normalization,
+  removed height normalization, removed XCTest coverage, stale plan status, and
+  missing verification evidence.
+- Exact-base comparison confirmed Xcode projects, podspecs, assets, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact and secret-pattern scans passed.
+- Hosted macOS XCTest and CodeQL evidence is recorded separately after push;
+  this plan claims only the completed local static verification.

--- a/docs/plans/2026-06-13-nan-min-image-size.md
+++ b/docs/plans/2026-06-13-nan-min-image-size.md
@@ -1,0 +1,47 @@
+# Normalize NaN Minimum Image Sizes
+
+status: planned
+
+## Context
+
+`minImageSize` clamps negative dimensions to zero, but comparisons with NaN are
+false. A NaN width or height therefore survives configuration and can propagate
+through layout `max(...)`, aspect sizing, and child image frames.
+
+## Requirements
+
+- R1. A NaN minimum-image width must normalize to zero.
+- R2. A NaN minimum-image height must normalize to zero.
+- R3. Each valid companion dimension must be preserved when the other dimension
+  is NaN.
+- R4. Existing negative-dimension clamping and ordinary positive sizing must
+  remain unchanged.
+- R5. Hosted XCTest and the deterministic checker must reject missing or
+  one-sided NaN handling.
+
+## Scope Boundaries
+
+- Do not change rating, touch, bounce, image-pair, or layout coordinate behavior.
+- Do not edit CocoaPods metadata, Xcode project settings, assets, or workflow
+  configuration.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations must reject removed width or height normalization, removed
+  XCTest coverage, stale plan status, and missing verification evidence.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -118,10 +118,12 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0) {
         didSet {
-            if minImageSize.width < 0 || minImageSize.height < 0 {
+            if minImageSize.width != minImageSize.width ||
+                minImageSize.height != minImageSize.height ||
+                minImageSize.width < 0 || minImageSize.height < 0 {
                 minImageSize = CGSize(
-                    width: max(CGFloat(0.0), minImageSize.width),
-                    height: max(CGFloat(0.0), minImageSize.height)
+                    width: minImageSize.width != minImageSize.width ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.width),
+                    height: minImageSize.height != minImageSize.height ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.height)
                 )
             }
             self.setNeedsLayout()

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -86,6 +86,19 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(hrv.minImageSize.height == 0)
     }
 
+    func testMinImageSizeDoesNotStayNaN() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let nan = CGFloat(Float(0.0) / Float(0.0))
+
+        hrv.minImageSize = CGSize(width: nan, height: 12)
+        XCTAssert(hrv.minImageSize.width == 0)
+        XCTAssert(hrv.minImageSize.height == 12)
+
+        hrv.minImageSize = CGSize(width: 15, height: nan)
+        XCTAssert(hrv.minImageSize.width == 15)
+        XCTAssert(hrv.minImageSize.height == 0)
+    }
+
     func testLayoutUsesLocalBoundsWhenViewIsScaled() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,6 +23,7 @@ HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation
 NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
+NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 
 
 def require(condition, message, failures):
@@ -106,6 +107,7 @@ def main():
         "docs/plans/2026-06-10-nan-rating-boundary.md",
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
         "docs/plans/2026-06-13-incomplete-image-pair.md",
+        "docs/plans/2026-06-13-nan-min-image-size.md",
     ]
 
     for relative_path in required_files:
@@ -167,9 +169,14 @@ def main():
     require("if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0" in rating_view,
             "sizeForImage must guard zero-sized images and containers",
             failures)
-    require("if minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
+    require("minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
             "minImageSize = CGSize" in rating_view and "setNeedsLayout()" in rating_view,
             "minImageSize must be clamped to non-negative values and trigger layout",
+            failures)
+    require("minImageSize.width != minImageSize.width" in rating_view and
+            "minImageSize.height != minImageSize.height" in rating_view and
+            rating_view.count("? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.") == 2,
+            "minImageSize must normalize NaN width and height independently",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -223,6 +230,11 @@ def main():
     require("testMaxRatingDoesNotStayBelowOne" in tests and "testZeroSizeImageReturnsZeroSize" in tests and
             "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
             "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
+            "testMinImageSizeDoesNotStayNaN" in tests and
+            "CGSize(width: nan, height: 12)" in tests and
+            "CGSize(width: 15, height: nan)" in tests and
+            "XCTAssert(hrv.minImageSize.height == 12)" in tests and
+            "XCTAssert(hrv.minImageSize.width == 15)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
             "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
@@ -272,6 +284,7 @@ def main():
     nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
+    nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -287,6 +300,12 @@ def main():
             failures)
     require("incomplete image pair" in readme.lower(),
             "README must document fail-closed rendering for incomplete image pairs",
+            failures)
+    require("NaN `minImageSize` dimensions normalize independently" in readme and
+            "NaN `minImageSize` dimensions must normalize to zero" in security and
+            "Normalize NaN `minImageSize` dimensions" in vision and
+            "Normalized NaN `minImageSize` width and height independently" in changes,
+            "Docs must record NaN minimum-image-size normalization",
             failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
@@ -349,6 +368,34 @@ def main():
             "All four Make gates" in incomplete_image_plan and
             "hostile mutations" in incomplete_image_plan.lower(),
             "incomplete image pair plan must record completed status and actual verification",
+            failures)
+    nan_min_image_size_statuses = re.findall(
+        r"^status: .+$", nan_min_image_size_plan, flags=re.MULTILINE
+    )
+    nan_min_image_size_sections = nan_min_image_size_plan.split(
+        "## Verification Completed\n", 1
+    )
+    nan_min_image_size_verification = (
+        nan_min_image_size_sections[1]
+        if len(nan_min_image_size_sections) == 2 else ""
+    )
+    nan_min_image_size_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "ruby -c iHeartRating.podspec",
+        "git diff --check",
+        "Five isolated hostile mutations",
+        "Hosted macOS XCTest and CodeQL evidence",
+    )
+    require(nan_min_image_size_statuses == ["status: completed"]
+            and all(item in nan_min_image_size_verification
+                    for item in nan_min_image_size_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          nan_min_image_size_verification,
+                          re.IGNORECASE) is None,
+            "NaN minImageSize plan must record completed status and actual local verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

NaN minimum-image dimensions no longer propagate into rating layout frames. Each invalid dimension falls back to zero while the valid companion dimension is preserved.

## Baseline

This PR is stacked on `lfg/iheartrating-incomplete-image-pair-20260613` (PR #14). Rating bounds, touch behavior, bounce animation, image-pair handling, local-bounds layout, package metadata, and workflow configuration remain unchanged.

## Improvements

- Normalize NaN width and height independently in the `minImageSize` setter.
- Preserve the existing negative clamp and ordinary positive sizes.
- Add hosted XCTest coverage for both one-sided NaN assignments and static mutation-resistant contracts.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- `ruby -c iHeartRating.podspec`
- `git diff --check`
- Five isolated hostile mutations rejected
- Exact-base preservation and intended-file artifact/secret scans passed
- Local gates truthfully reported `xcodebuild` unavailable; hosted macOS XCTest is required

## Risk

The setter change affects only NaN dimensions. Static and hosted project checks cannot replace simulator rendering on the legacy Swift/Xcode toolchain.

## Follow-Ups

- Record exact-head hosted XCTest and code-scanning evidence after canonical checks complete.
- Keep PR #14 available and merge the stack in base order; do not merge this PR independently.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
