### PR TITLE
fix: normalize infinite image sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Normalized infinite `minImageSize` width and height independently to zero
+  while preserving valid companion dimensions.
 - Normalized NaN `minImageSize` width and height independently to zero while
   preserving valid companion dimensions.
 - Made incomplete image pair configuration hide full rating overlays and clear

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 NaN `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
+Infinite `minImageSize` dimensions normalize independently to zero while valid
+companion dimensions are preserved.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ Helpful reports include:
   for bounce animation indexing.
 - NaN `minImageSize` dimensions must normalize to zero before layout geometry is
   calculated.
+- Infinite `minImageSize` dimensions must normalize to zero before layout
+  geometry is calculated.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,7 @@ Priority:
 - Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
 - Normalize NaN `minImageSize` dimensions before image layout
+- Normalize infinite `minImageSize` dimensions before image layout
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/docs/plans/2026-06-13-infinite-min-image-size.md
+++ b/docs/plans/2026-06-13-infinite-min-image-size.md
@@ -1,0 +1,43 @@
+# Infinite Minimum Image Size Normalization
+
+status: planned
+
+## Context
+
+`minImageSize` normalizes negative and NaN dimensions, but positive infinity
+still survives the property observer. Layout then selects an infinite maximum
+dimension and can assign non-finite frames to the empty and full rating image
+views.
+
+## Requirements
+
+- R1. Normalize positive and negative infinite width or height values to zero.
+- R2. Normalize each dimension independently so a valid companion dimension is
+  preserved.
+- R3. Preserve existing NaN and negative-dimension normalization.
+- R4. Keep compatibility with the repository's Swift 2-era public API and
+  legacy Xcode project.
+- R5. Add XCTest intent and mutation-sensitive static coverage without changing
+  project files, assets, podspecs, or hosted workflow policy.
+
+## Scope Boundaries
+
+- Do not change rating bounds, touch behavior, image-pair visibility, bounce
+  animation, or layout spacing.
+- Do not modernize Swift syntax or project settings in this compatibility fix.
+- Local Linux validation must remain truthful about unavailable `xcodebuild`.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations must reject loss of width or height infinity guards,
+  companion-dimension preservation, stale plan status, and missing verification
+  evidence.

--- a/docs/plans/2026-06-13-infinite-min-image-size.md
+++ b/docs/plans/2026-06-13-infinite-min-image-size.md
@@ -1,6 +1,6 @@
 # Infinite Minimum Image Size Normalization
 
-status: planned
+status: completed
 
 ## Context
 
@@ -41,3 +41,30 @@ views.
 - Hostile mutations must reject loss of width or height infinity guards,
   companion-dimension preservation, stale plan status, and missing verification
   evidence.
+
+## Work Completed
+
+- Normalized positive and negative infinite width and height values
+  independently to zero in the `minImageSize` setter.
+- Preserved valid companion dimensions and the existing NaN and negative-value
+  behavior.
+- Added XCTest intent for infinite width and height assignments.
+- Extended static contracts and configuration documentation without changing
+  project, podspec, asset, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`,
+  `ruby -c iHeartRating.podspec`,
+  `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`, and `git diff --check`
+  passed.
+- Five isolated hostile mutations were rejected: removed width infinity guard,
+  removed height infinity guard, lost companion-dimension preservation, stale
+  plan status, and missing verification evidence.
+- Exact-base comparison confirmed Xcode projects, podspecs, assets, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact and secret-pattern scans passed.
+- Hosted macOS project parsing and CodeQL evidence is recorded separately after
+  push; this plan claims only the completed local static verification.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -4,6 +4,7 @@
 //
 
 import UIKit
+import Darwin
 
 @objc public protocol HeartRatingViewDelegate {
     /**
@@ -118,12 +119,15 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0) {
         didSet {
-            if minImageSize.width != minImageSize.width ||
-                minImageSize.height != minImageSize.height ||
-                minImageSize.width < 0 || minImageSize.height < 0 {
+            let widthIsInvalid = minImageSize.width != minImageSize.width ||
+                isinf(Double(minImageSize.width)) || minImageSize.width < 0
+            let heightIsInvalid = minImageSize.height != minImageSize.height ||
+                isinf(Double(minImageSize.height)) || minImageSize.height < 0
+
+            if widthIsInvalid || heightIsInvalid {
                 minImageSize = CGSize(
-                    width: minImageSize.width != minImageSize.width ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.width),
-                    height: minImageSize.height != minImageSize.height ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.height)
+                    width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width,
+                    height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height
                 )
             }
             self.setNeedsLayout()

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -99,6 +99,24 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(hrv.minImageSize.height == 0)
     }
 
+    func testMinImageSizeDoesNotStayPositiveInfinity() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let infinity = CGFloat(1.0) / CGFloat(0.0)
+
+        hrv.minImageSize = CGSize(width: infinity, height: 12)
+        XCTAssert(hrv.minImageSize.width == 0)
+        XCTAssert(hrv.minImageSize.height == 12)
+    }
+
+    func testMinImageSizeDoesNotStayNegativeInfinity() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let negativeInfinity = CGFloat(-1.0) / CGFloat(0.0)
+
+        hrv.minImageSize = CGSize(width: 15, height: negativeInfinity)
+        XCTAssert(hrv.minImageSize.width == 15)
+        XCTAssert(hrv.minImageSize.height == 0)
+    }
+
     func testLayoutUsesLocalBoundsWhenViewIsScaled() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,7 @@ NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
+INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 
 
 def require(condition, message, failures):
@@ -108,6 +109,7 @@ def main():
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
         "docs/plans/2026-06-13-incomplete-image-pair.md",
         "docs/plans/2026-06-13-nan-min-image-size.md",
+        "docs/plans/2026-06-13-infinite-min-image-size.md",
     ]
 
     for relative_path in required_files:
@@ -169,14 +171,22 @@ def main():
     require("if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0" in rating_view,
             "sizeForImage must guard zero-sized images and containers",
             failures)
-    require("minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
+    require("minImageSize.width < 0" in rating_view and
+            "minImageSize.height < 0" in rating_view and
             "minImageSize = CGSize" in rating_view and "setNeedsLayout()" in rating_view,
             "minImageSize must be clamped to non-negative values and trigger layout",
             failures)
     require("minImageSize.width != minImageSize.width" in rating_view and
             "minImageSize.height != minImageSize.height" in rating_view and
-            rating_view.count("? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.") == 2,
+            "width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width" in rating_view and
+            "height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height" in rating_view,
             "minImageSize must normalize NaN width and height independently",
+            failures)
+    require("isinf(Double(minImageSize.width))" in rating_view and
+            "isinf(Double(minImageSize.height))" in rating_view and
+            "func testMinImageSizeDoesNotStayPositiveInfinity()" in tests and
+            "func testMinImageSizeDoesNotStayNegativeInfinity()" in tests,
+            "minImageSize must normalize infinite width and height independently",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -285,6 +295,7 @@ def main():
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
+    infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -306,6 +317,12 @@ def main():
             "Normalize NaN `minImageSize` dimensions" in vision and
             "Normalized NaN `minImageSize` width and height independently" in changes,
             "Docs must record NaN minimum-image-size normalization",
+            failures)
+    require("Infinite `minImageSize` dimensions normalize independently" in readme and
+            "Infinite `minImageSize` dimensions must normalize to zero" in security and
+            "Normalize infinite `minImageSize` dimensions" in vision and
+            "Normalized infinite `minImageSize` width and height independently" in changes,
+            "Docs must record infinite minimum-image-size normalization",
             failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
@@ -396,6 +413,33 @@ def main():
                           nan_min_image_size_verification,
                           re.IGNORECASE) is None,
             "NaN minImageSize plan must record completed status and actual local verification",
+            failures)
+    infinite_min_image_size_statuses = re.findall(
+        r"^status: .+$", infinite_min_image_size_plan, flags=re.MULTILINE
+    )
+    infinite_min_image_size_sections = infinite_min_image_size_plan.split(
+        "## Verification Completed\n", 1
+    )
+    infinite_min_image_size_verification = (
+        infinite_min_image_size_sections[1]
+        if len(infinite_min_image_size_sections) == 2 else ""
+    )
+    infinite_min_image_size_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "ruby -c iHeartRating.podspec",
+        "git diff --check",
+        "Five isolated hostile mutations",
+    )
+    require(infinite_min_image_size_statuses == ["status: completed"]
+            and all(item in infinite_min_image_size_verification
+                    for item in infinite_min_image_size_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          infinite_min_image_size_verification,
+                          re.IGNORECASE) is None,
+            "infinite minImageSize plan must record completed status and actual local verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

- Normalize positive and negative infinite `minImageSize` dimensions independently to zero.
- Preserve valid companion dimensions and existing NaN/negative handling.
- Add XCTest intent, mutation-sensitive static contracts, documentation, and completed local plan evidence.

## Baseline

This PR is stacked on PR #15 (`lfg/iheartrating-nan-min-image-size-20260613`) and should be reviewed after its base branch. Existing NaN and negative-dimension handling remains the base for this focused infinity boundary.

## Improvements

- Detect positive and negative infinity independently for each `minImageSize` dimension.
- Normalize only the invalid infinite dimension to zero.
- Preserve a valid companion dimension.
- Retain existing NaN and negative-value behavior.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- Both podspec syntax checks.
- `git diff --check`
- Five isolated hostile mutations.
- Intended-path secret-pattern and generated-artifact scans.
- Local Linux validation truthfully reported `xcodebuild` unavailable.

## Risk

Only infinite `minImageSize` dimensions change behavior. Runtime XCTest execution remains unavailable on the local Linux host because `xcodebuild` is not installed.

## Follow-Ups

- Review and merge the stack in base order, keeping PR #15 available until this successor is integrated.
- Run the intended XCTest coverage on an available Apple toolchain.
