### PR TITLE
fix: make iHeartRating checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made every Make verification target derive the checkout root so the static
+  rating-view baseline works from external directories.
 - Normalized infinite `minImageSize` width and height independently to zero
   while preserving valid companion dimensions.
 - Normalized NaN `minImageSize` width and height independently to zero while

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
+	@python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Maintenance Notes
 
+- Every Make verification target derives the checkout root from the loaded
+  Makefile, so an absolute Makefile path works from any working directory.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,6 +1,6 @@
 # Location-Independent iHeartRating Verification
 
-status: planned
+status: completed
 
 ## Context
 
@@ -23,11 +23,21 @@ caller instead of the checkout.
 
 ## Work Completed
 
-Pending implementation.
+- Derived the checkout root from the loaded Makefile and invoked the checker
+  through its absolute path.
+- Added rooted invocation, completed-plan evidence, and synchronized guidance.
+- Preserved Swift, tests, project, podspec, build script, and workflow files.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- Root and external-directory Make gates passed for all four aliases.
+- The root-derivation mutation failed.
+- The checker-invocation mutation failed.
+- The plan-status mutation failed.
+- The plan-evidence mutation failed.
+- The documentation mutation failed.
+- Checker compilation, shell and podspec syntax, XML/plist parsing, diff
+  hygiene, intended-path review, secret scanning, and artifact inspection passed.
 
 ## Risk And Rollback
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,34 @@
+# Location-Independent iHeartRating Verification
+
+status: planned
+
+## Context
+
+Absolute Makefile invocations resolve the maintained checker relative to the
+caller instead of the checkout.
+
+## Scope
+
+1. Derive the checkout root from `MAKEFILE_LIST`.
+2. Invoke the Python checker through its rooted path.
+3. Add completed-plan, external-run, guidance, and mutation contracts.
+4. Preserve Swift, tests, project, podspec, build script, and workflow files.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and a temporary directory.
+- Run checker compilation, shell/podspec syntax, XML/plist parsing, and diff checks.
+- Reject root, checker, plan status/evidence, and documentation mutations.
+- Inspect intended paths, secrets, and generated artifacts.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.
+
+## Risk And Rollback
+
+Verification path resolution only; rollback restores the relative recipe.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 
 
 def require(condition, message, failures):
@@ -110,6 +111,7 @@ def main():
         "docs/plans/2026-06-13-incomplete-image-pair.md",
         "docs/plans/2026-06-13-nan-min-image-size.md",
         "docs/plans/2026-06-13-infinite-min-image-size.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
     ]
 
     for relative_path in required_files:
@@ -296,10 +298,17 @@ def main():
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
             failures)
+    require("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and '@python3 "$(ROOT)/scripts/check-baseline.py"' in makefile,
+            "Makefile must invoke the checker through the loaded checkout root", failures)
+    require("absolute Makefile path" in readme and "any working directory" in readme,
+            "README must document location-independent verification", failures)
+    require("Make verification target derive the checkout root" in changes and "external directories" in changes,
+            "CHANGES must record location-independent verification", failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "podspec" in readme and "delegate-independent bounce" in readme and "non-editable" in readme and "empty touch" in readme.lower() and "minImageSize" in readme and "image layout invalidation" in readme and "local bounds" in readme.lower(),
             "README must document static verification, build script, and podspec expectations",
             failures)
@@ -441,6 +450,12 @@ def main():
                           re.IGNORECASE) is None,
             "infinite minImageSize plan must record completed status and actual local verification",
             failures)
+    location_statuses = re.findall(r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE)
+    location_sections = location_independent_make_plan.split("## Verification Completed\n", 1)
+    location_verification = location_sections[1] if len(location_sections) == 2 else ""
+    location_required = ("Root and external-directory Make gates passed", "root-derivation mutation failed", "checker-invocation mutation failed", "plan-status mutation failed", "plan-evidence mutation failed", "documentation mutation failed")
+    require(location_statuses == ["status: completed"] and all(item in location_verification for item in location_required) and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification, re.IGNORECASE) is None,
+            "location-independent Make plan must record completed verification", failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
     )


### PR DESCRIPTION
## Summary
- Makefile verification now roots the checker invocation to the loaded checkout, allowing the project gates to run from outside the repository directory.
- The remediation also enforces completed-plan evidence and location-independent operator guidance while preserving product files.

## Baseline
- The Make checker invocation previously depended on the caller's working directory.
- Swift, tests, projects, podspecs, build scripts, dependencies, and workflows remain outside this verification-focused change.

## Improvements
- Root the Make checker invocation to the loaded checkout.
- Enforce completed-plan evidence and location-independent guidance.
- Preserve Swift, tests, projects, podspecs, build scripts, and workflow files unchanged.

## Validation
- All four Make gates from both the checkout and `/tmp`
- Checker compilation, shell syntax, and podspec syntax
- Five hostile mutations rejected
- Diff, intended-path, secret-like addition, and generated-artifact checks

## Risk
- This is a verification-only stacked change.
- PR #16 must merge or otherwise be reconciled before this PR is delivered.

## Follow-Ups
- Merge or reconcile PR #16 before delivering this stacked change.
- Address broader Swift, test, project, podspec, build-script, dependency, or workflow modernization separately with behavior-specific validation.
