### PR TITLE
fix: propagate rating image content mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 - UI configuration changes should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, or out-of-range ratings.
 - Keep rating image layout in local bounds coordinates so transforms do not
   distort child geometry.
+- Ensure `imageContentMode` changes propagate to every existing image view.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Made `imageContentMode` changes propagate to every existing image view and
+  added regression coverage for all empty and full image pairs.
+
 ## 2026-06-13
 
 - Made every Make verification target derive the checkout root so the static

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ NaN `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
 Infinite `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
+`imageContentMode` changes propagate to every existing image view so already
+created empty and full image pairs stay synchronized with the configured mode.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,8 @@ Helpful reports include:
   calculated.
 - Infinite `minImageSize` dimensions must normalize to zero before layout
   geometry is calculated.
+- `imageContentMode` changes propagate to every existing image view so rendered
+  children cannot retain stale configuration.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Normalize NaN rating assignments before rendering and animation indexing
 - Normalize NaN `minImageSize` dimensions before image layout
 - Normalize infinite `minImageSize` dimensions before image layout
+- Ensure `imageContentMode` changes propagate to every existing image view
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/docs/plans/2026-06-14-image-content-mode-propagation.md
+++ b/docs/plans/2026-06-14-image-content-mode-propagation.md
@@ -1,0 +1,47 @@
+# Image Content Mode Propagation
+
+status: planned
+
+## Context
+
+`HeartRatingView` applies `imageContentMode` only while image views are first
+created. Updating the property later leaves all existing empty and full image
+views on the previous mode, so the configured view state and rendered children
+diverge.
+
+## Priority
+
+This is a narrow reusable-view consistency defect. The fix should update the
+already-created image views without changing rating, touch, animation, or image
+layout behavior.
+
+## Scope
+
+1. Propagate every `imageContentMode` assignment to existing empty and full
+   image views.
+2. Request layout after propagation so geometry can respond to the new mode.
+3. Add an XCTest covering both halves of every existing image pair.
+4. Add mutation-sensitive static and plan contracts plus synchronized guidance.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through the absolute Makefile
+  path from an external directory.
+- Run checker compilation, `build.sh` syntax, and both podspec syntax checks.
+- Reject mutations that remove content-mode propagation, its XCTest, plan
+  completion, or recorded evidence.
+- Inspect the exact diff, generated artifacts, and changed lines for secrets.
+
+## Risk And Rollback
+
+The change only updates existing child `UIImageView.contentMode` values and
+requests layout. Rollback restores initialization-only behavior; no persisted
+data or network behavior is involved.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and exact evidence.

--- a/docs/plans/2026-06-14-image-content-mode-propagation.md
+++ b/docs/plans/2026-06-14-image-content-mode-propagation.md
@@ -1,6 +1,6 @@
 # Image Content Mode Propagation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,8 +40,25 @@ data or network behavior is involved.
 
 ## Work Completed
 
-Pending implementation.
+- Added an `imageContentMode` property observer that updates all existing empty
+  and full image views and requests layout.
+- Added an XCTest that verifies all ten default image views adopt the changed
+  content mode.
+- Added static implementation, test, documentation, and completed-plan
+  contracts plus synchronized maintenance guidance.
 
 ## Verification Completed
 
-Pending implementation and exact evidence.
+- All four Make gates passed in an isolated completed-plan preflight copy and
+  again in the implementation worktree.
+- The absolute Makefile check passed from an external directory.
+- `python3 -m py_compile scripts/check-baseline.py` passed; its exact generated
+  bytecode path was removed before the final artifact audit.
+- `sh -n build.sh` passed.
+- Both podspec syntax checks passed with `ruby -c`.
+- Four isolated hostile mutations were rejected: removing either propagation
+  loop, removing the observer layout request, and removing XCTest discovery.
+- `git diff --check` passed, along with exact intended-path, generated-artifact,
+  changed-line secret, dependency, vendored-file, project, and workflow audits.
+- Local `xcodebuild` was unavailable on Linux; no full Swift 2 compile or
+  simulator execution is claimed.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -70,7 +70,17 @@ public class HeartRatingView: UIView {
     /**
      Sets the empty and full image view content mode.
      */
-    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit
+    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
+        didSet {
+            for imageView in self.emptyImageViews {
+                imageView.contentMode = imageContentMode
+            }
+            for imageView in self.fullImageViews {
+                imageView.contentMode = imageContentMode
+            }
+            self.setNeedsLayout()
+        }
+    }
     
     /**
      Minimum rating.

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -133,6 +133,18 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
     }
 
+    func testImageContentModeUpdatesExistingImageViews() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+
+        hrv.imageContentMode = UIViewContentMode.ScaleAspectFill
+
+        XCTAssert(hrv.subviews.count == 10)
+        for subview in hrv.subviews {
+            let imageView = subview as! UIImageView
+            XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)
+        }
+    }
+
     func testIncompleteImagePairHidesAndRestoresFullImages() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-14-image-content-mode-propagation.md"
 
 
 def require(condition, message, failures):
@@ -112,6 +113,7 @@ def main():
         "docs/plans/2026-06-13-nan-min-image-size.md",
         "docs/plans/2026-06-13-infinite-min-image-size.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-14-image-content-mode-propagation.md",
     ]
 
     for relative_path in required_files:
@@ -233,6 +235,18 @@ def main():
     require(rating_view.count("if touches.isEmpty") >= 3,
             "touchesBegan, touchesMoved, and touchesEnded must all guard empty touch sets",
             failures)
+    content_mode_observer = re.search(
+        r"var imageContentMode: UIViewContentMode = UIViewContentMode\.ScaleAspectFit \{(?P<body>.*?)\n    \}",
+        rating_view,
+        re.DOTALL,
+    )
+    require(content_mode_observer is not None and
+            "for imageView in self.emptyImageViews" in content_mode_observer.group("body") and
+            "for imageView in self.fullImageViews" in content_mode_observer.group("body") and
+            content_mode_observer.group("body").count("imageView.contentMode = imageContentMode") == 2 and
+            "self.setNeedsLayout()" in content_mode_observer.group("body"),
+            "imageContentMode changes must update every existing image view and request layout",
+            failures)
     require(incomplete_image_branch is not None and
             "for imageView in self.fullImageViews" in incomplete_image_branch.group("body") and
             "imageView.layer.mask = nil" in incomplete_image_branch.group("body") and
@@ -249,6 +263,10 @@ def main():
             "XCTAssert(hrv.minImageSize.width == 15)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
+            "testImageContentModeUpdatesExistingImageViews" in tests and
+            "hrv.imageContentMode = UIViewContentMode.ScaleAspectFill" in tests and
+            "XCTAssert(hrv.subviews.count == 10)" in tests and
+            "XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)" in tests and
             "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
             "XCTAssertTrue(firstFullImageView.hidden)" in tests and
             "XCTAssertNil(firstFullImageView.layer.mask)" in tests and
@@ -299,6 +317,7 @@ def main():
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    image_content_mode_plan = IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if IMAGE_CONTENT_MODE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -359,6 +378,15 @@ def main():
             failures)
     require("incomplete image pair" in changes.lower(),
             "CHANGES must record incomplete image-pair rendering behavior",
+            failures)
+    content_mode_guidance = "imageContentMode changes propagate to every existing image view"
+    normalized_guidance = [
+        " ".join(document.replace("`", "").split())
+        for document in [readme, vision, security, changes, read("AGENTS.md")]
+    ]
+    require(all(content_mode_guidance in document
+                for document in normalized_guidance),
+            "project guidance must document image content-mode propagation",
             failures)
     require("status: completed" in baseline_plan and "status: completed" in rating_bounds_plan and "status: completed" in bounce_plan,
             "plans must be marked completed",
@@ -456,6 +484,33 @@ def main():
     location_required = ("Root and external-directory Make gates passed", "root-derivation mutation failed", "checker-invocation mutation failed", "plan-status mutation failed", "plan-evidence mutation failed", "documentation mutation failed")
     require(location_statuses == ["status: completed"] and all(item in location_verification for item in location_required) and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification, re.IGNORECASE) is None,
             "location-independent Make plan must record completed verification", failures)
+    image_content_mode_statuses = re.findall(
+        r"^status: .+$", image_content_mode_plan, flags=re.MULTILINE
+    )
+    image_content_mode_sections = image_content_mode_plan.split(
+        "## Verification Completed\n", 1
+    )
+    image_content_mode_verification = (
+        image_content_mode_sections[1]
+        if len(image_content_mode_sections) == 2 else ""
+    )
+    image_content_mode_required = (
+        "All four Make gates",
+        "absolute Makefile check",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "Both podspec syntax checks",
+        "Four isolated hostile mutations",
+        "git diff --check",
+    )
+    require(image_content_mode_statuses == ["status: completed"]
+            and all(item in image_content_mode_verification
+                    for item in image_content_mode_required)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          image_content_mode_verification,
+                          re.IGNORECASE) is None,
+            "image content-mode propagation plan must record completed verification",
+            failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
     )


### PR DESCRIPTION
## Summary

Keep existing rating image views synchronized when `imageContentMode` changes after initialization. The property observer now updates every empty and full image view and requests layout.

## Baseline

This is a narrow stacked change based on `lfg/iheartrating-location-independent-make-20260613` (PR #17). Rating normalization, image geometry, mask rendering, touch handling, animation, project metadata, and the compact API surface are preserved.

## Improvements

- Propagate content-mode assignments to all existing image-view pairs.
- Request layout after propagation.
- Add XCTest coverage across all ten default child image views.
- Add static implementation, test, documentation, and completed-plan contracts.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- External-directory invocation through the absolute Makefile path
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- `ruby -c iHeartRating.podspec`
- `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`
- Four isolated hostile mutations covering both propagation loops, layout invalidation, and XCTest discovery
- Exact diff, generated-artifact, changed-line secret, dependency, vendored-file, project, and workflow audits
- Main-thread correctness, Swift lifecycle, maintainability, security, testing, and project-standards review: no actionable findings

Local `xcodebuild` is unavailable on Linux, so no full Swift 2 compile or simulator execution is claimed. Browser validation is not applicable to this UIKit library change.

## Risk

The property now performs bounded work proportional to `maxRating` whenever its content mode changes. The default view updates ten child image views and requests one layout pass.

## Follow-Ups

Interactive rendering on Xcode 7.3 remains part of the archival toolchain validation boundary.

## Post-Deploy Monitoring & Validation

On the next compatible simulator or device run, change the content mode after the rating view has rendered and confirm every empty/full image pair updates without geometry drift. Roll back this commit if any child retains its old mode or layout behavior regresses.

[![Engineering Baseline](https://img.shields.io/badge/engineering%20baseline-validated-brightgreen)](docs/plans/2026-06-14-image-content-mode-propagation.md)
