### PR TITLE
fix: expose rating image content mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - Keep rating image layout in local bounds coordinates so transforms do not
   distort child geometry.
 - Ensure `imageContentMode` changes propagate to every existing image view.
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2026-06-17
+
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
+
 ## 2026-06-14
 
 - Made `imageContentMode` changes propagate to every existing image view and

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Infinite `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
 `imageContentMode` changes propagate to every existing image view so already
 created empty and full image pairs stay synchronized with the configured mode.
+External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,7 @@ Helpful reports include:
   geometry is calculated.
 - `imageContentMode` changes propagate to every existing image view so rendered
   children cannot retain stale configuration.
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Normalize NaN `minImageSize` dimensions before image layout
 - Normalize infinite `minImageSize` dimensions before image layout
 - Ensure `imageContentMode` changes propagate to every existing image view
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/docs/plans/2026-06-17-public-image-content-mode.md
+++ b/docs/plans/2026-06-17-public-image-content-mode.md
@@ -1,0 +1,74 @@
+---
+title: "fix: Expose image content mode to library consumers"
+type: fix
+date: 2026-06-17
+status: planned
+---
+
+# fix: Expose image content mode to library consumers
+
+## Summary
+
+Make `HeartRatingView.imageContentMode` part of the public library API so
+applications importing iHeartRating can configure the rendering mode that the
+view already propagates to every empty and full rating image.
+
+## Problem Frame
+
+The property is documented as configurable and its observer correctly updates
+existing child views, but its declaration has internal access. The current
+XCTest target uses `@testable import`, so its propagation test passes even
+though an external CocoaPods or framework consumer cannot assign the property.
+
+## Requirements
+
+- R1. `imageContentMode` must be publicly readable and writable from an
+  importing application.
+- R2. The default must remain `ScaleAspectFit`.
+- R3. Assignments must continue updating every existing empty and full image
+  view and requesting layout.
+- R4. The property must not become `@IBInspectable`; the legacy Interface
+  Builder inspection surface does not support arbitrary enum properties.
+- R5. Maintained checks and documentation must reject a regression to internal
+  access, removal of propagation, stale plan status, or missing verification.
+
+## Implementation Units
+
+### U1. Correct the library access boundary
+
+- **Files:** `iHeartRating/iHeartRatingView.swift`.
+- **Approach:** Add public access to the existing property declaration without
+  changing its type, default, observer, layout invalidation, or child-view
+  initialization behavior.
+- **Verification:** Source inspection confirms the public declaration and the
+  existing propagation test remains intact.
+
+### U2. Protect the consumer contract
+
+- **Files:** `scripts/check-baseline.py`, `README.md`, `VISION.md`,
+  `SECURITY.md`, `CHANGES.md`, `AGENTS.md`, this plan.
+- **Approach:** Add an exact public-surface contract and synchronized guidance
+  that distinguishes external configurability from internal `@testable`
+  coverage.
+- **Verification:** Root and external-directory Make gates pass; isolated
+  mutations removing public access, propagation, guidance, plan status, or
+  plan evidence fail for their intended reason.
+
+## Scope Boundaries
+
+- Do not rename the property or change its `UIViewContentMode` type.
+- Do not change rating, touch, mask, animation, or layout behavior.
+- Do not modernize the Swift 2 syntax, deployment target, pod version, or
+  archival Xcode projects in this change.
+
+## Risks
+
+- This expands the source-compatible public API but does not change binary or
+  persisted-data formats.
+- Linux cannot compile the UIKit module; static public-surface contracts and
+  hosted Xcode project parsing remain the available verification boundary.
+
+## Related Work
+
+- `docs/plans/2026-06-14-image-content-mode-propagation.md` established the
+  observer behavior this change exposes to consumers.

--- a/docs/plans/2026-06-17-public-image-content-mode.md
+++ b/docs/plans/2026-06-17-public-image-content-mode.md
@@ -2,7 +2,7 @@
 title: "fix: Expose image content mode to library consumers"
 type: fix
 date: 2026-06-17
-status: planned
+status: completed
 ---
 
 # fix: Expose image content mode to library consumers
@@ -72,3 +72,25 @@ though an external CocoaPods or framework consumer cannot assign the property.
 
 - `docs/plans/2026-06-14-image-content-mode-propagation.md` established the
   observer behavior this change exposes to consumers.
+
+## Work Completed
+
+- Made the existing `imageContentMode` property publicly readable and writable
+  without changing its type, default, observer, or child-view behavior.
+- Added a maintained source contract that distinguishes public API access from
+  the legacy XCTest target's `@testable` visibility.
+- Synchronized consumer and maintainer guidance without expanding the
+  Interface Builder, deployment, or package-version surface.
+
+## Verification Completed
+
+- All four Make gates passed: `make lint`, `make test`, `make build`, and
+  `make check`.
+- The external-directory absolute Makefile check passed from `/tmp`.
+- `xcodebuild` was unavailable locally, so the maintained static source,
+  project, plist, workflow, podspec, documentation, and plan contracts ran.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, both
+  podspec syntax checks, and `git diff --check` passed.
+- Seven isolated hostile mutations were rejected for public access, the
+  default mode, Interface Builder exposure, observer propagation, guidance,
+  plan status, and plan evidence.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -70,7 +70,7 @@ public class HeartRatingView: UIView {
     /**
      Sets the empty and full image view content mode.
      */
-    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
+    public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
         didSet {
             for imageView in self.emptyImageViews {
                 imageView.contentMode = imageContentMode

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -27,6 +27,7 @@ NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-14-image-content-mode-propagation.md"
+PUBLIC_IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-17-public-image-content-mode.md"
 
 
 def require(condition, message, failures):
@@ -114,6 +115,7 @@ def main():
         "docs/plans/2026-06-13-infinite-min-image-size.md",
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-image-content-mode-propagation.md",
+        "docs/plans/2026-06-17-public-image-content-mode.md",
     ]
 
     for relative_path in required_files:
@@ -191,6 +193,10 @@ def main():
             "func testMinImageSizeDoesNotStayPositiveInfinity()" in tests and
             "func testMinImageSizeDoesNotStayNegativeInfinity()" in tests,
             "minImageSize must normalize infinite width and height independently",
+            failures)
+    require("public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit" in rating_view and
+            "@IBInspectable public var imageContentMode" not in rating_view,
+            "imageContentMode must remain a public non-IBInspectable consumer API",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -318,6 +324,7 @@ def main():
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     image_content_mode_plan = IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if IMAGE_CONTENT_MODE_PLAN.exists() else ""
+    public_image_content_mode_plan = PUBLIC_IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if PUBLIC_IMAGE_CONTENT_MODE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -510,6 +517,39 @@ def main():
                           image_content_mode_verification,
                           re.IGNORECASE) is None,
             "image content-mode propagation plan must record completed verification",
+            failures)
+    public_image_content_mode_guidance = "External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized."
+    require(all(public_image_content_mode_guidance in document for document in
+                [read("AGENTS.md"), readme, security, vision, changes]),
+            "Docs must record the public imageContentMode consumer contract",
+            failures)
+    public_image_content_mode_statuses = re.findall(
+        r"^status: .+$", public_image_content_mode_plan, flags=re.MULTILINE
+    )
+    public_image_content_mode_sections = public_image_content_mode_plan.split(
+        "## Verification Completed\n", 1
+    )
+    public_image_content_mode_verification = (
+        public_image_content_mode_sections[1]
+        if len(public_image_content_mode_sections) == 2 else ""
+    )
+    public_image_content_mode_required = (
+        "All four Make gates passed",
+        "external-directory absolute Makefile check passed from `/tmp`",
+        "`xcodebuild` was unavailable locally",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "podspec syntax checks",
+        "git diff --check",
+        "Seven isolated hostile mutations were rejected",
+    )
+    require(public_image_content_mode_statuses == ["status: completed"] and
+            all(item in public_image_content_mode_verification
+                    for item in public_image_content_mode_required) and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      public_image_content_mode_verification,
+                      re.IGNORECASE) is None,
+            "public imageContentMode plan must record completed verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

Applications importing iHeartRating can now configure `HeartRatingView.imageContentMode`. The documented property is genuinely public instead of appearing accessible only because the XCTest target imports the module with `@testable`.

## Baseline

`imageContentMode` was documented as a consumer configuration point but declared with internal access. Tests could access it through `@testable import`, masking the fact that normal downstream applications could not compile code that set the property.

## Improvements

- Exposes the existing `imageContentMode` stored property as public API.
- Preserves its type and `ScaleAspectFit` default.
- Leaves observer propagation and layout invalidation unchanged.
- Does not expand the Interface Builder surface.
- Updates maintained contracts to distinguish genuine public access from test-only module visibility.

## Validation

- Exact head `cef1933578565582f811864c83d88bd8aadc9443` is open, clean, and mergeable on PR #19.
- Push run `27699886071` and pull-request run `27699889929` both completed the exact-head hosted `baseline` job successfully.
- `make lint`, `make test`, `make build`, and `make check` passed.
- The external-directory absolute-Makefile check passed.
- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, and both podspec syntax checks passed.
- Seven isolated API, observer, documentation, and plan mutations were rejected.
- Requirements R1-R5 were checked directly.
- Escalated public API review found no actionable issues.
- The hosted macOS project parse remains the available platform check because local Linux cannot compile the legacy UIKit and Swift 2 module.

## Risk

This is a public access-control change, so the property becomes part of the library's supported source API. Its type, default, observer behavior, and layout behavior remain unchanged, limiting runtime risk. Validation still depends on an archival compatible macOS toolchain for full downstream compilation.

## Follow-Ups

- Compile a small downstream application that imports iHeartRating normally and sets `imageContentMode` without `@testable`.
- Preserve the property's current type, default, and observer semantics in future compatibility changes.
- No service monitoring is required because this is a source-level library correction with no deployed runtime, logging, metrics, or configuration.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
