### PR TITLE
fix: consolidate and harden the rating control stack

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   baseline:
     runs-on: macos-15
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -23,3 +23,5 @@ jobs:
           persist-credentials: false
       - name: Validate projects and rating baseline
         run: make check
+      - name: Build and test the rating control
+        run: make xcode-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,14 @@
 
 - Install dependencies: no repository-specific install command is documented.
 - Full baseline: `make check`
+- Executable iOS gate: `make xcode-test`
 - Local Apple development: `open iHeartRating.xcodeproj`
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 
 ## Coding conventions
 
 - Language mix noted in the README: Swift (6), C/C++ headers (1), shell (1).
-- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+- Preserve the Swift 5, iOS 12, and signing-independent project settings unless a change explicitly updates supported platforms.
 
 ## Testing guidance
 
@@ -39,7 +40,7 @@
 - Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
 - Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
 - Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
-- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+- Call out skipped simulator/device/visual validation and any risky files touched in the final summary.
 
 ## Safety and gotchas
 
@@ -49,7 +50,8 @@
   distort child geometry.
 - Ensure `imageContentMode` changes propagate to every existing image view.
 - External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
-- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- Keep intrinsic sizing, hostile-geometry bounds, accessibility state, and generated Objective-C selectors covered by tests.
+- Treat `HeartRatingView` mutation as main-thread-only UIKit work.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-bounce-without-delegate.md` for the bounce-without-delegate guardrail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 - UI configuration changes should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, or out-of-range ratings.
 - Keep rating image layout in local bounds coordinates so transforms do not
   distort child geometry.
+- Ensure `imageContentMode` changes propagate to every existing image view.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - Keep rating image layout in local bounds coordinates so transforms do not
   distort child geometry.
 - Ensure `imageContentMode` changes propagate to every existing image view.
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Made incomplete image pair configuration hide full rating overlays and clear
+  stale masks until both images are configured again.
+
 ## 2026-06-10
 
 - Normalized NaN rating assignments to `minRating` before rendering or bounce

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 2026-06-19
+
+- Migrated the library, tests, and SampleApp from unbuildable Swift 2 project
+  settings to Swift 5 with an iOS 12 deployment target.
+- Prepared CocoaPods `0.2.0` metadata for the Swift 5/iOS 12 compatibility
+  boundary while preserving external subclassing and Objective-C selectors.
+- Added executable hosted simulator tests and generated Objective-C header
+  checks while preserving the `heartRatingView:didUpdate:` and
+  `heartRatingView:isUpdating:` selectors.
+- Bounded hostile and extreme layout geometry before creating image frames or
+  partial-rating masks, and added stable repeated-layout coverage.
+- Capped `maxRating` at 100 before allocating paired image views.
+- Added intrinsic content sizing for complete image pairs and zero intrinsic
+  size for incomplete pairs.
+- Added synchronized adjustable accessibility label, value, traits, and bounded
+  increment/decrement actions.
+- Updated CocoaPods metadata with the tested iOS and Swift versions.
+
 ## 2026-06-17
 
 - External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Made `imageContentMode` changes propagate to every existing image view and
+  added regression coverage for all empty and full image pairs.
+
 ## 2026-06-13
 
 - Made every Make verification target derive the checkout root so the static

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Normalized NaN `minImageSize` width and height independently to zero while
+  preserving valid companion dimensions.
 - Made incomplete image pair configuration hide full rating overlays and clear
   stale masks until both images are configured again.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2026-06-17
+
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
+
 ## 2026-06-14
 
 - Made `imageContentMode` changes propagate to every existing image view and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Normalized infinite `minImageSize` width and height independently to zero
+  while preserving valid companion dimensions.
 - Normalized NaN `minImageSize` width and height independently to zero while
   preserving valid companion dimensions.
 - Made incomplete image pair configuration hide full rating overlays and clear

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made every Make verification target derive the checkout root so the static
+  rating-view baseline works from external directories.
 - Normalized infinite `minImageSize` width and height independently to zero
   while preserving valid companion dimensions.
 - Normalized NaN `minImageSize` width and height independently to zero while

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
+	@python3 "$(ROOT)/scripts/check-baseline.py"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: build check lint test
+.PHONY: build check lint test xcode-test
 
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
+
+xcode-test:
+	@"$(ROOT)/build.sh"
 
 check:
 	@python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ An incomplete image pair renders no full overlays: clearing either image hides
 filled ratings and removes stale masks until both images are configured again.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
+NaN `minImageSize` dimensions normalize independently to zero while valid
+companion dimensions are preserved.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Infinite `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
 `imageContentMode` changes propagate to every existing image view so already
 created empty and full image pairs stay synchronized with the configured mode.
+External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Maintenance Notes
 
+- Every Make verification target derives the checkout root from the loaded
+  Makefile, so an absolute Makefile path works from any working directory.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Additional scan context:
 ### Prerequisites
 
 - Git
-- macOS with Xcode for building Apple platform projects
+- macOS with a current Xcode release for building Apple platform projects
+- iOS 12 or newer for consumers
 - Python 3 for local static verification on non-macOS hosts
 
 ### Setup
@@ -48,9 +49,13 @@ make lint
 make test
 make build
 make check
+make xcode-test
 ```
 
-The setup commands above validate the static baseline. Full simulator builds still require macOS with Xcode.
+The first four commands validate the location-independent static baseline.
+`make xcode-test` selects an available iPhone simulator, runs the library XCTest
+suite, checks the generated Objective-C compatibility header, and builds the
+sample application.
 
 ## Running or Using the Project
 
@@ -69,9 +74,9 @@ make build
 make check
 ```
 
-The `lint`, `test`, and `build` targets intentionally alias the static baseline
-on hosts without the legacy Xcode toolchain, so the standard local gate commands
-stay available while preserving the single source of truth.
+The `lint`, `test`, and `build` targets intentionally alias the static baseline.
+Use `make xcode-test` for executable Swift, UIKit, Objective-C interoperability,
+and sample-project evidence.
 
 The baseline parses plist/storyboard/SVG files, validates both podspecs, checks `build.sh` shell syntax, verifies rating-view guards for empty, single-item, zero-size, negative `minImageSize`, invalid `maxRating`, rating bounds, non-editable touch endings, empty touch endings, empty began/moved touch events, out-of-range bounce configurations, and delegate-independent bounce behavior, and reports when Xcode is unavailable.
 It also keeps non-editable began/moved touch events from sending live-update
@@ -91,15 +96,22 @@ companion dimensions are preserved.
 `imageContentMode` changes propagate to every existing image view so already
 created empty and full image pairs stay synchronized with the configured mode.
 External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
+Complete image pairs provide an intrinsic content size derived from the larger
+configured image, `minImageSize`, and `maxRating`; incomplete pairs have zero
+intrinsic size and clear stale filled-image masks.
+Hostile NaN, infinite, negative, zero, and extreme finite geometry is normalized
+or bounded before frames and masks reach Core Animation.
+`maxRating` is capped at 100 before child image views are allocated, preventing
+unbounded memory growth from malformed configuration.
+The control is one adjustable accessibility element with a default `Rating`
+label, a synchronized `<value> of <max>` value, and bounded increment/decrement
+actions. Consumers may replace the accessibility label for localization.
+As with UIKit generally, create and mutate `HeartRatingView` on the main thread.
 
-The pinned, credential-free GitHub Actions check runs `make check` on
-`macos-15`. When Xcode is available, the baseline parses both
-`iHeartRating.xcodeproj` and the SampleApp project with `xcodebuild -list`.
-This verifies project-file integrity but does not claim that Swift 2 sources
-compile on a current Xcode toolchain.
-
-For full legacy verification, use Xcode 7.3 with its matching simulator runtime
-and run Xcode's test action, `xcodebuild test`, or `./build.sh`.
+The pinned, credential-free GitHub Actions check runs both `make check` and
+`make xcode-test` on `macos-15`. The projects pin Swift 5 and iOS 12, the hosted
+gate executes XCTest on a simulator, inspects the generated Swift-to-Objective-C
+header, and compiles the SampleApp without signing.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ It also keeps image layout invalidation in the rating image setters so runtime
 image changes recalculate frames before masks refresh.
 Rating image geometry is calculated from the view's local bounds so transforms
 do not inflate or misalign child images.
+An incomplete image pair renders no full overlays: clearing either image hides
+filled ratings and removes stale masks until both images are configured again.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 
@@ -108,6 +110,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   refresh work runs.
 - Rating image layout should use local bounds rather than transformed frame
   dimensions.
+- An incomplete image pair should hide full overlays and clear stale masks
+  until both rating images are configured.
 
 ## Maintenance Notes
 
@@ -128,6 +132,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   normalization.
 - See `docs/plans/2026-06-12-bounds-based-image-layout.md` for transformed-view
   layout correctness.
+- See `docs/plans/2026-06-13-incomplete-image-pair.md` for fail-closed image-pair
+  rendering.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, podspecs, plist/storyboard files, or build scripts.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ NaN `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
 Infinite `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
+`imageContentMode` changes propagate to every existing image view so already
+created empty and full image pairs stay synchronized with the configured mode.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ NaN programmatic ratings fall back to `minRating` before mask rendering or
 bounce animation indexing.
 NaN `minImageSize` dimensions normalize independently to zero while valid
 companion dimensions are preserved.
+Infinite `minImageSize` dimensions normalize independently to zero while valid
+companion dimensions are preserved.
 
 The pinned, credential-free GitHub Actions check runs `make check` on
 `macos-15`. When Xcode is available, the baseline parses both

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ Helpful reports include:
   for bounce animation indexing.
 - NaN `minImageSize` dimensions must normalize to zero before layout geometry is
   calculated.
+- Infinite `minImageSize` dimensions must normalize to zero before layout
+  geometry is calculated.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,8 @@ Helpful reports include:
   calculated.
 - Infinite `minImageSize` dimensions must normalize to zero before layout
   geometry is calculated.
+- `imageContentMode` changes propagate to every existing image view so rendered
+  children cannot retain stale configuration.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,9 @@ Helpful reports include:
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 - `make check` runs a static baseline for malformed configuration hardening, CocoaPods metadata, plist/storyboard parsing, build-script syntax, rating bounds, and rating-view edge cases when Xcode is unavailable.
 - The pinned macOS workflow uses read-only repository permissions, disables
-  checkout credential persistence, and parses both Xcode projects without
-  signing material or package publication access.
+  checkout credential persistence, runs the simulator XCTest suite, checks the
+  generated Objective-C header, and builds the SampleApp without signing or
+  package publication access.
 - Rating controls should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, out-of-range ratings, non-editable touch endings, empty touch endings, or unexpected image assets.
 - NaN ratings must be normalized before mask calculations or integer conversion
   for bounce animation indexing.
@@ -48,6 +49,15 @@ Helpful reports include:
   avoiding oversized or misaligned interactive regions.
 - An incomplete image pair should hide full overlays and remove stale masks
   rather than displaying a rating without its empty-image baseline.
+- Extreme finite dimensions are bounded before multiplication or Core Animation
+  frame assignment so malformed configuration cannot produce non-finite layout.
+- `maxRating` is capped before allocating paired child image views to prevent
+  malformed configuration from causing unbounded memory growth.
+- Complete image pairs expose finite intrinsic sizing for Auto Layout;
+  incomplete pairs expose zero intrinsic size.
+- The control exposes one adjustable accessibility element and keeps its value
+  and traits synchronized with rating and editability changes.
+- `HeartRatingView` follows UIKit's main-thread-only mutation contract.
 
 ## Mobile Privacy Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.
+- An incomplete image pair should hide full overlays and remove stale masks
+  rather than displaying a rating without its empty-image baseline.
 
 ## Mobile Privacy Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,7 @@ Helpful reports include:
   geometry is calculated.
 - `imageContentMode` changes propagate to every existing image view so rendered
   children cannot retain stale configuration.
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,8 @@ Helpful reports include:
 - Rating controls should not crash on empty image arrays, single-rating views, zero-sized images, negative `minImageSize`, invalid `maxRating`, inconsistent rating bounds, out-of-range ratings, non-editable touch endings, empty touch endings, or unexpected image assets.
 - NaN ratings must be normalized before mask calculations or integer conversion
   for bounce animation indexing.
+- NaN `minImageSize` dimensions must normalize to zero before layout geometry is
+  calculated.
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
   syntax
 - Keep image layout invalidation tied to runtime rating image changes
 - Keep child image geometry in the rating view's local bounds coordinate space
+- Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
@@ -68,6 +69,8 @@ Image layout invalidation should run when rating images change so masks refresh
 against current frames.
 Scaled or rotated rating views should continue laying out child images from
 local bounds rather than transformed frame dimensions.
+An incomplete image pair should render without full overlays or stale masks,
+then restore normal rating rendering when both images are configured.
 On macOS, the baseline should also parse both Xcode projects. Full Swift 2
 compilation and simulator testing remain tied to Xcode 7.3 and a compatible
 runtime.

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Normalize NaN rating assignments before rendering and animation indexing
 - Normalize NaN `minImageSize` dimensions before image layout
 - Normalize infinite `minImageSize` dimensions before image layout
+- Ensure `imageContentMode` changes propagate to every existing image view
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Keep child image geometry in the rating view's local bounds coordinate space
 - Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
+- Normalize NaN `minImageSize` dimensions before image layout
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,7 @@ Priority:
 - Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
 - Normalize NaN `minImageSize` dimensions before image layout
+- Normalize infinite `minImageSize` dimensions before image layout
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Normalize NaN `minImageSize` dimensions before image layout
 - Normalize infinite `minImageSize` dimensions before image layout
 - Ensure `imageContentMode` changes propagate to every existing image view
+- External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep pinned, credential-free macOS CI parsing both Xcode projects through the

--- a/VISION.md
+++ b/VISION.md
@@ -34,14 +34,14 @@ Priority:
 - External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized.
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
-- Keep pinned, credential-free macOS CI parsing both Xcode projects through the
-  canonical `make check` gate
+- Keep pinned, credential-free macOS CI running static contracts, simulator
+  XCTest, Objective-C header checks, and the SampleApp build
 
 Next priorities:
 
-- Modernize Swift/project settings in a dedicated pass
-- Add tests for rating calculations and delegate calls
-- Clarify package-manager support if revived
+- Add visual regression coverage for image spacing and content modes
+- Add spoken VoiceOver and Switch Control device verification
+- Clarify Swift Package Manager support if the library is revived
 
 Contribution rules:
 
@@ -60,10 +60,9 @@ This UI component has low security risk, but it should not crash on malformed
 configuration or unexpected image assets.
 
 Current baseline: `make lint`, `make test`, `make build`, and `make check` run
-`scripts/check-baseline.py` without Xcode. It verifies static project metadata,
-CocoaPods specs, plist/storyboard files, build script syntax, and rating-view
-guards for empty, single-item, zero-size, negative `minImageSize`, invalid
-`maxRating`, inconsistent rating bounds, and out-of-range bounce configurations.
+`scripts/check-baseline.py`. It verifies static project metadata, CocoaPods
+specs, plist/storyboard files, build-script syntax, Objective-C selectors,
+finite geometry, intrinsic sizing, accessibility, and rating-view guards.
 Bounce animation should remain independent of delegate callbacks, and
 non-editable views or empty touch endings should ignore touch-ending delegate
 and bounce work. Empty began/moved touch events should ignore live-update
@@ -75,9 +74,8 @@ Scaled or rotated rating views should continue laying out child images from
 local bounds rather than transformed frame dimensions.
 An incomplete image pair should render without full overlays or stale masks,
 then restore normal rating rendering when both images are configured.
-On macOS, the baseline should also parse both Xcode projects. Full Swift 2
-compilation and simulator testing remain tied to Xcode 7.3 and a compatible
-runtime.
+On macOS, `make xcode-test` runs the Swift 5 XCTest suite on an available iPhone
+simulator, verifies the generated Objective-C header, and builds the SampleApp.
 
 ## What We Will Not Merge (For Now)
 

--- a/build.sh
+++ b/build.sh
@@ -2,18 +2,50 @@
 
 set -eu
 
-if ! command -v xcodebuild >/dev/null 2>&1; then
-    echo "xcodebuild not found; install Xcode to run the iHeartRating test build." >&2
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+if ! command -v xcodebuild >/dev/null 2>&1 || ! command -v xcrun >/dev/null 2>&1; then
+    echo "Xcode is required to run the iHeartRating build and test gate." >&2
     exit 127
 fi
 
-ci_lib() {
-    NAME="$1"
-    xcodebuild -project iHeartRating.xcodeproj \
-               -scheme "iHeartRatingTests" \
-               -destination "platform=iOS Simulator,name=${NAME}" \
-               -sdk iphonesimulator \
-               build test
-}
+DERIVED_DATA=$(mktemp -d "${TMPDIR:-/tmp}/iHeartRating-derived.XXXXXX")
+SAMPLE_DERIVED_DATA=$(mktemp -d "${TMPDIR:-/tmp}/iHeartRating-sample-derived.XXXXXX")
+trap 'rm -rf "$DERIVED_DATA" "$SAMPLE_DERIVED_DATA"' EXIT HUP INT TERM
 
-ci_lib "iPhone 5"
+SIMULATOR_ID=${IOS_SIMULATOR_ID:-$(xcrun simctl list devices available -j | python3 -c '
+import json, sys
+devices = json.load(sys.stdin).get("devices", {})
+for runtime in sorted(devices, reverse=True):
+    for device in devices[runtime]:
+        if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
+            print(device["udid"])
+            raise SystemExit(0)
+raise SystemExit("no available iPhone simulator found")
+')}
+DESTINATION="platform=iOS Simulator,id=${SIMULATOR_ID}"
+
+xcodebuild \
+    -project "$ROOT/iHeartRating.xcodeproj" \
+    -scheme iHeartRatingTests \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    CODE_SIGNING_ALLOWED=NO \
+    test
+
+GENERATED_HEADER=$(find "$DERIVED_DATA" -path '*/iHeartRating.framework/Headers/iHeartRating-Swift.h' -print -quit)
+if [ -z "$GENERATED_HEADER" ]; then
+    echo "Generated Objective-C compatibility header was not found." >&2
+    exit 1
+fi
+grep -E '@property .*UIViewContentMode imageContentMode;' "$GENERATED_HEADER" >/dev/null
+grep -E 'heartRatingView:.*didUpdate:\(float\)rating;' "$GENERATED_HEADER" >/dev/null
+grep -E 'heartRatingView:.*isUpdating:\(float\)rating;' "$GENERATED_HEADER" >/dev/null
+
+xcodebuild \
+    -project "$ROOT/example/SampleApp/SampleApp.xcodeproj" \
+    -scheme SampleApp \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$SAMPLE_DERIVED_DATA" \
+    CODE_SIGNING_ALLOWED=NO \
+    build

--- a/docs/plans/2026-06-12-bounds-based-image-layout.md
+++ b/docs/plans/2026-06-12-bounds-based-image-layout.md
@@ -27,3 +27,25 @@ misaligned content.
 - `git diff --check`
 - A mutation that restores `frame`-based image sizing must fail the baseline.
 - Hosted macOS validation must parse both Xcode projects.
+
+## Work Completed
+
+- Changed child image sizing, spacing, and origin calculations to use the
+  rating view's local `bounds` coordinate space.
+- Preserved minimum image sizing, the single-image path, parser behavior,
+  touch handling, and package metadata.
+- Added transformed-view XCTest coverage and a dependency-free static contract
+  rejecting frame-based layout regressions.
+
+## Verification Completed
+
+- All four Make gates, checker compilation, `bash -n build.sh`, and
+  `git diff --check` passed locally; Xcode project parsing was truthfully
+  skipped because Xcode is unavailable in the local environment.
+- Implementation push run `27394309114` and pull-request run `27394315070`
+  passed at commit `542646ef0f910afe803638be316194d4995654b7`; the hosted macOS
+  gate parsed both Xcode projects and ran the rating baseline.
+- Post-merge push run `27394330649` and CodeQL setup run `27402322718` passed
+  at default-branch merge commit `7077f27aeed5950d99fc4944ac436d007136f193`.
+- A mutation restoring `frame`-based image sizing was rejected by the
+  baseline.

--- a/docs/plans/2026-06-13-incomplete-image-pair.md
+++ b/docs/plans/2026-06-13-incomplete-image-pair.md
@@ -1,6 +1,6 @@
 # Incomplete Rating Image Pair
 
-status: planned
+status: completed
 
 ## Context
 
@@ -68,3 +68,17 @@ stored rating or rebuilding image views.
 - `git diff --check`
 - Hostile mutations removing the nil guard, mask cleanup, early return,
   regression test, plan status, or verification evidence must be rejected.
+
+## Verification Completed
+
+- All four Make gates (`make lint`, `make test`, `make build`, and
+  `make check`) passed against the completed implementation and plan.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, both
+  `ruby -c` podspec checks, and `git diff --check` passed.
+- A prepared baseline passed and eight hostile mutations were rejected. The
+  mutations removed either side of the nil guard, mask cleanup, overlay hiding,
+  the early return, the regression test, the stale-mask assertion, or completed
+  plan status or required verification evidence.
+- `xcodebuild` was unavailable on this Linux host, so the legacy Swift 2 XCTest
+  suite was not executed locally. The canonical baseline reported the static
+  iOS-only limitation rather than claiming simulator coverage.

--- a/docs/plans/2026-06-13-incomplete-image-pair.md
+++ b/docs/plans/2026-06-13-incomplete-image-pair.md
@@ -1,0 +1,70 @@
+# Incomplete Rating Image Pair
+
+status: planned
+
+## Context
+
+`HeartRatingView` overlays full images on empty images. When `emptyImage` is
+cleared after layout, its image views become empty but `refresh()` can leave the
+previous full overlays visible according to the current rating.
+
+The control can therefore display a rating without its configured empty-image
+baseline, even though layout depends on that image pair.
+
+## Priority
+
+Image configuration is public and mutable. An incomplete pair should render no
+filled rating rather than stale or misleading overlays, without changing the
+stored rating or rebuilding image views.
+
+## Requirements
+
+- R1. `refresh()` must hide every full image view when either `emptyImage` or
+  `fullImage` is nil.
+- R2. Hidden full image views must have stale masks removed.
+- R3. Completing the image pair must restore normal whole, half, and floating
+  rating rendering through the existing refresh path.
+- R4. Rating values, image-view counts, layout math, bounce behavior, and
+  delegate callbacks must remain unchanged.
+- R5. Add XCTest coverage for clearing and restoring the image pair plus a
+  static early-return contract.
+
+## Implementation Units
+
+### U1. Fail closed for incomplete images
+
+- **Files:** `iHeartRating/iHeartRatingView.swift`
+- Add an early refresh boundary that clears masks, hides full overlays, and
+  returns before rating-based visibility logic.
+
+### U2. Extend regression coverage
+
+- **Files:** `iHeartRatingTests/iHeartRatingTests.swift`,
+  `scripts/check-baseline.py`
+- Prove overlay hiding after image removal and restoration after reconfiguration.
+
+### U3. Document the rendering boundary
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record deterministic rendering for incomplete image configuration.
+
+## Scope Boundaries
+
+- Do not change the public rating API, image layout, touch math, or animation.
+- Do not modernize Swift, Xcode, deployment targets, podspec versions, or the
+  example app.
+- Do not claim local simulator execution when Xcode is unavailable.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations removing the nil guard, mask cleanup, early return,
+  regression test, plan status, or verification evidence must be rejected.

--- a/docs/plans/2026-06-13-infinite-min-image-size.md
+++ b/docs/plans/2026-06-13-infinite-min-image-size.md
@@ -1,0 +1,43 @@
+# Infinite Minimum Image Size Normalization
+
+status: planned
+
+## Context
+
+`minImageSize` normalizes negative and NaN dimensions, but positive infinity
+still survives the property observer. Layout then selects an infinite maximum
+dimension and can assign non-finite frames to the empty and full rating image
+views.
+
+## Requirements
+
+- R1. Normalize positive and negative infinite width or height values to zero.
+- R2. Normalize each dimension independently so a valid companion dimension is
+  preserved.
+- R3. Preserve existing NaN and negative-dimension normalization.
+- R4. Keep compatibility with the repository's Swift 2-era public API and
+  legacy Xcode project.
+- R5. Add XCTest intent and mutation-sensitive static coverage without changing
+  project files, assets, podspecs, or hosted workflow policy.
+
+## Scope Boundaries
+
+- Do not change rating bounds, touch behavior, image-pair visibility, bounce
+  animation, or layout spacing.
+- Do not modernize Swift syntax or project settings in this compatibility fix.
+- Local Linux validation must remain truthful about unavailable `xcodebuild`.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations must reject loss of width or height infinity guards,
+  companion-dimension preservation, stale plan status, and missing verification
+  evidence.

--- a/docs/plans/2026-06-13-infinite-min-image-size.md
+++ b/docs/plans/2026-06-13-infinite-min-image-size.md
@@ -1,6 +1,6 @@
 # Infinite Minimum Image Size Normalization
 
-status: planned
+status: completed
 
 ## Context
 
@@ -41,3 +41,30 @@ views.
 - Hostile mutations must reject loss of width or height infinity guards,
   companion-dimension preservation, stale plan status, and missing verification
   evidence.
+
+## Work Completed
+
+- Normalized positive and negative infinite width and height values
+  independently to zero in the `minImageSize` setter.
+- Preserved valid companion dimensions and the existing NaN and negative-value
+  behavior.
+- Added XCTest intent for infinite width and height assignments.
+- Extended static contracts and configuration documentation without changing
+  project, podspec, asset, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`,
+  `ruby -c iHeartRating.podspec`,
+  `ruby -c iHeartRating/0.1.6/iHeartRating.podspec`, and `git diff --check`
+  passed.
+- Five isolated hostile mutations were rejected: removed width infinity guard,
+  removed height infinity guard, lost companion-dimension preservation, stale
+  plan status, and missing verification evidence.
+- Exact-base comparison confirmed Xcode projects, podspecs, assets, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact and secret-pattern scans passed.
+- Hosted macOS project parsing and CodeQL evidence is recorded separately after
+  push; this plan claims only the completed local static verification.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,6 +1,6 @@
 # Location-Independent iHeartRating Verification
 
-status: planned
+status: completed
 
 ## Context
 
@@ -23,11 +23,21 @@ caller instead of the checkout.
 
 ## Work Completed
 
-Pending implementation.
+- Derived the checkout root from the loaded Makefile and invoked the checker
+  through its absolute path.
+- Added rooted invocation, completed-plan evidence, and synchronized guidance.
+- Preserved Swift, tests, project, podspec, build script, and workflow files.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- Root and external-directory Make gates passed for all four aliases.
+- The root-derivation mutation failed.
+- The checker-invocation mutation failed.
+- The plan-status mutation failed.
+- The plan-evidence mutation failed.
+- The documentation mutation failed.
+- Checker compilation, shell and podspec syntax, XML/plist parsing, diff
+  hygiene, intended-path review, secret scanning, and artifact inspection passed.
 
 ## Risk And Rollback
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,34 @@
+# Location-Independent iHeartRating Verification
+
+status: planned
+
+## Context
+
+Absolute Makefile invocations resolve the maintained checker relative to the
+caller instead of the checkout.
+
+## Scope
+
+1. Derive the checkout root from `MAKEFILE_LIST`.
+2. Invoke the Python checker through its rooted path.
+3. Add completed-plan, external-run, guidance, and mutation contracts.
+4. Preserve Swift, tests, project, podspec, build script, and workflow files.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and a temporary directory.
+- Run checker compilation, shell/podspec syntax, XML/plist parsing, and diff checks.
+- Reject root, checker, plan status/evidence, and documentation mutations.
+- Inspect intended paths, secrets, and generated artifacts.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.
+
+## Risk And Rollback
+
+Verification path resolution only; rollback restores the relative recipe.

--- a/docs/plans/2026-06-13-nan-min-image-size.md
+++ b/docs/plans/2026-06-13-nan-min-image-size.md
@@ -1,6 +1,6 @@
 # Normalize NaN Minimum Image Sizes
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,8 +40,25 @@ through layout `max(...)`, aspect sizing, and child image frames.
 
 ## Work Completed
 
-Pending implementation.
+- Normalized NaN width and height values independently to zero in the
+  `minImageSize` setter.
+- Preserved each valid companion dimension and the existing negative-value
+  clamp.
+- Added hosted XCTest cases for NaN width and NaN height assignments.
+- Extended static contracts and configuration documentation without changing
+  rating, touch, project, podspec, or workflow behavior.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- All four Make gates passed locally and reported that `xcodebuild` was
+  unavailable, so only the static iOS baseline ran on this host.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`,
+  `ruby -c iHeartRating.podspec`, and `git diff --check` passed.
+- Five isolated hostile mutations were rejected: removed width normalization,
+  removed height normalization, removed XCTest coverage, stale plan status, and
+  missing verification evidence.
+- Exact-base comparison confirmed Xcode projects, podspecs, assets, and hosted
+  workflow configuration remained unchanged.
+- Intended-file generated-artifact and secret-pattern scans passed.
+- Hosted macOS XCTest and CodeQL evidence is recorded separately after push;
+  this plan claims only the completed local static verification.

--- a/docs/plans/2026-06-13-nan-min-image-size.md
+++ b/docs/plans/2026-06-13-nan-min-image-size.md
@@ -1,0 +1,47 @@
+# Normalize NaN Minimum Image Sizes
+
+status: planned
+
+## Context
+
+`minImageSize` clamps negative dimensions to zero, but comparisons with NaN are
+false. A NaN width or height therefore survives configuration and can propagate
+through layout `max(...)`, aspect sizing, and child image frames.
+
+## Requirements
+
+- R1. A NaN minimum-image width must normalize to zero.
+- R2. A NaN minimum-image height must normalize to zero.
+- R3. Each valid companion dimension must be preserved when the other dimension
+  is NaN.
+- R4. Existing negative-dimension clamping and ordinary positive sizing must
+  remain unchanged.
+- R5. Hosted XCTest and the deterministic checker must reject missing or
+  one-sided NaN handling.
+
+## Scope Boundaries
+
+- Do not change rating, touch, bounce, image-pair, or layout coordinate behavior.
+- Do not edit CocoaPods metadata, Xcode project settings, assets, or workflow
+  configuration.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `sh -n build.sh`
+- `ruby -c iHeartRating.podspec`
+- `git diff --check`
+- Hostile mutations must reject removed width or height normalization, removed
+  XCTest coverage, stale plan status, and missing verification evidence.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/docs/plans/2026-06-14-image-content-mode-propagation.md
+++ b/docs/plans/2026-06-14-image-content-mode-propagation.md
@@ -1,0 +1,47 @@
+# Image Content Mode Propagation
+
+status: planned
+
+## Context
+
+`HeartRatingView` applies `imageContentMode` only while image views are first
+created. Updating the property later leaves all existing empty and full image
+views on the previous mode, so the configured view state and rendered children
+diverge.
+
+## Priority
+
+This is a narrow reusable-view consistency defect. The fix should update the
+already-created image views without changing rating, touch, animation, or image
+layout behavior.
+
+## Scope
+
+1. Propagate every `imageContentMode` assignment to existing empty and full
+   image views.
+2. Request layout after propagation so geometry can respond to the new mode.
+3. Add an XCTest covering both halves of every existing image pair.
+4. Add mutation-sensitive static and plan contracts plus synchronized guidance.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through the absolute Makefile
+  path from an external directory.
+- Run checker compilation, `build.sh` syntax, and both podspec syntax checks.
+- Reject mutations that remove content-mode propagation, its XCTest, plan
+  completion, or recorded evidence.
+- Inspect the exact diff, generated artifacts, and changed lines for secrets.
+
+## Risk And Rollback
+
+The change only updates existing child `UIImageView.contentMode` values and
+requests layout. Rollback restores initialization-only behavior; no persisted
+data or network behavior is involved.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and exact evidence.

--- a/docs/plans/2026-06-14-image-content-mode-propagation.md
+++ b/docs/plans/2026-06-14-image-content-mode-propagation.md
@@ -1,6 +1,6 @@
 # Image Content Mode Propagation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -40,8 +40,25 @@ data or network behavior is involved.
 
 ## Work Completed
 
-Pending implementation.
+- Added an `imageContentMode` property observer that updates all existing empty
+  and full image views and requests layout.
+- Added an XCTest that verifies all ten default image views adopt the changed
+  content mode.
+- Added static implementation, test, documentation, and completed-plan
+  contracts plus synchronized maintenance guidance.
 
 ## Verification Completed
 
-Pending implementation and exact evidence.
+- All four Make gates passed in an isolated completed-plan preflight copy and
+  again in the implementation worktree.
+- The absolute Makefile check passed from an external directory.
+- `python3 -m py_compile scripts/check-baseline.py` passed; its exact generated
+  bytecode path was removed before the final artifact audit.
+- `sh -n build.sh` passed.
+- Both podspec syntax checks passed with `ruby -c`.
+- Four isolated hostile mutations were rejected: removing either propagation
+  loop, removing the observer layout request, and removing XCTest discovery.
+- `git diff --check` passed, along with exact intended-path, generated-artifact,
+  changed-line secret, dependency, vendored-file, project, and workflow audits.
+- Local `xcodebuild` was unavailable on Linux; no full Swift 2 compile or
+  simulator execution is claimed.

--- a/docs/plans/2026-06-17-public-image-content-mode.md
+++ b/docs/plans/2026-06-17-public-image-content-mode.md
@@ -1,0 +1,74 @@
+---
+title: "fix: Expose image content mode to library consumers"
+type: fix
+date: 2026-06-17
+status: planned
+---
+
+# fix: Expose image content mode to library consumers
+
+## Summary
+
+Make `HeartRatingView.imageContentMode` part of the public library API so
+applications importing iHeartRating can configure the rendering mode that the
+view already propagates to every empty and full rating image.
+
+## Problem Frame
+
+The property is documented as configurable and its observer correctly updates
+existing child views, but its declaration has internal access. The current
+XCTest target uses `@testable import`, so its propagation test passes even
+though an external CocoaPods or framework consumer cannot assign the property.
+
+## Requirements
+
+- R1. `imageContentMode` must be publicly readable and writable from an
+  importing application.
+- R2. The default must remain `ScaleAspectFit`.
+- R3. Assignments must continue updating every existing empty and full image
+  view and requesting layout.
+- R4. The property must not become `@IBInspectable`; the legacy Interface
+  Builder inspection surface does not support arbitrary enum properties.
+- R5. Maintained checks and documentation must reject a regression to internal
+  access, removal of propagation, stale plan status, or missing verification.
+
+## Implementation Units
+
+### U1. Correct the library access boundary
+
+- **Files:** `iHeartRating/iHeartRatingView.swift`.
+- **Approach:** Add public access to the existing property declaration without
+  changing its type, default, observer, layout invalidation, or child-view
+  initialization behavior.
+- **Verification:** Source inspection confirms the public declaration and the
+  existing propagation test remains intact.
+
+### U2. Protect the consumer contract
+
+- **Files:** `scripts/check-baseline.py`, `README.md`, `VISION.md`,
+  `SECURITY.md`, `CHANGES.md`, `AGENTS.md`, this plan.
+- **Approach:** Add an exact public-surface contract and synchronized guidance
+  that distinguishes external configurability from internal `@testable`
+  coverage.
+- **Verification:** Root and external-directory Make gates pass; isolated
+  mutations removing public access, propagation, guidance, plan status, or
+  plan evidence fail for their intended reason.
+
+## Scope Boundaries
+
+- Do not rename the property or change its `UIViewContentMode` type.
+- Do not change rating, touch, mask, animation, or layout behavior.
+- Do not modernize the Swift 2 syntax, deployment target, pod version, or
+  archival Xcode projects in this change.
+
+## Risks
+
+- This expands the source-compatible public API but does not change binary or
+  persisted-data formats.
+- Linux cannot compile the UIKit module; static public-surface contracts and
+  hosted Xcode project parsing remain the available verification boundary.
+
+## Related Work
+
+- `docs/plans/2026-06-14-image-content-mode-propagation.md` established the
+  observer behavior this change exposes to consumers.

--- a/docs/plans/2026-06-17-public-image-content-mode.md
+++ b/docs/plans/2026-06-17-public-image-content-mode.md
@@ -2,7 +2,7 @@
 title: "fix: Expose image content mode to library consumers"
 type: fix
 date: 2026-06-17
-status: planned
+status: completed
 ---
 
 # fix: Expose image content mode to library consumers
@@ -72,3 +72,25 @@ though an external CocoaPods or framework consumer cannot assign the property.
 
 - `docs/plans/2026-06-14-image-content-mode-propagation.md` established the
   observer behavior this change exposes to consumers.
+
+## Work Completed
+
+- Made the existing `imageContentMode` property publicly readable and writable
+  without changing its type, default, observer, or child-view behavior.
+- Added a maintained source contract that distinguishes public API access from
+  the legacy XCTest target's `@testable` visibility.
+- Synchronized consumer and maintainer guidance without expanding the
+  Interface Builder, deployment, or package-version surface.
+
+## Verification Completed
+
+- All four Make gates passed: `make lint`, `make test`, `make build`, and
+  `make check`.
+- The external-directory absolute Makefile check passed from `/tmp`.
+- `xcodebuild` was unavailable locally, so the maintained static source,
+  project, plist, workflow, podspec, documentation, and plan contracts ran.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, both
+  podspec syntax checks, and `git diff --check` passed.
+- Seven isolated hostile mutations were rejected for public access, the
+  default mode, Interface Builder exposure, observer propagation, guidance,
+  plan status, and plan evidence.

--- a/docs/plans/2026-06-19-iheartrating-deep-review.md
+++ b/docs/plans/2026-06-19-iheartrating-deep-review.md
@@ -1,0 +1,85 @@
+# iHeartRating Deep Review Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Land the stacked rating-control fixes with finite layout geometry, useful Auto Layout sizing, accessible state, preserved Objective-C selectors, and real Xcode build/test evidence.
+
+**Architecture:** Preserve `HeartRatingView` as the single owner of rating state and child image views. Modernize the legacy Swift syntax without redesigning the public control, centralize finite geometry normalization at the layout boundary, derive intrinsic size from the configured image pair and rating count, and keep accessibility state synchronized from the same refresh path.
+
+**Tech Stack:** Swift 5, UIKit, XCTest, Xcode project builds, Python static baseline checks, GitHub Actions.
+
+---
+
+### Task 1: Establish Modern Build Failure
+
+**Files:**
+- Test: `iHeartRatingTests/iHeartRatingTests.swift`
+- Modify: `iHeartRating.xcodeproj/project.pbxproj`
+
+**Step 1:** Add focused modern XCTest cases for hostile geometry, repeated layout, intrinsic size, content-mode reinitialization, incomplete image pairs, and accessibility.
+
+**Step 2:** Run `xcodebuild` and record the expected legacy Swift configuration/syntax failure.
+
+**Step 3:** Set explicit Swift 5 project settings and modernize only the syntax required to compile the existing API and tests.
+
+**Step 4:** Re-run the narrow test target and confirm the new behavior tests fail for missing implementation rather than project configuration.
+
+### Task 2: Harden Geometry and Intrinsic Size
+
+**Files:**
+- Modify: `iHeartRating/iHeartRatingView.swift`
+- Test: `iHeartRatingTests/iHeartRatingTests.swift`
+
+**Step 1:** Verify hostile `NaN`, infinity, negative, zero, and extreme finite geometry tests fail.
+
+**Step 2:** Add one finite nonnegative normalization boundary and use it for `minImageSize`, `sizeForImage`, layout bounds, mask widths, and intrinsic-size multiplication.
+
+**Step 3:** Invalidate intrinsic content size when images, image count, or minimum image size changes.
+
+**Step 4:** Run the focused XCTest cases and confirm every generated frame, mask, and intrinsic dimension is finite and stable across repeated layout passes.
+
+### Task 3: Preserve API and Accessibility
+
+**Files:**
+- Modify: `iHeartRating/iHeartRatingView.swift`
+- Test: `iHeartRatingTests/iHeartRatingTests.swift`
+
+**Step 1:** Verify tests fail for missing adjustable traits, rating value, increment/decrement behavior, and image content mode after child-view replacement.
+
+**Step 2:** Preserve Objective-C delegate selectors with explicit `@objc` declarations and expose compatible public members through `@objcMembers`.
+
+**Step 3:** Make the view one accessibility element, synchronize label/value/traits, and implement bounded accessibility increment/decrement callbacks.
+
+**Step 4:** Run XCTest and inspect the generated Swift Objective-C header after a successful framework build.
+
+### Task 4: Make Validation Executable
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `build.sh`
+- Modify: `.github/workflows/check.yml`
+- Modify: `scripts/check-baseline.py`
+
+**Step 1:** Add a location-independent `make xcode-test` command using a concrete available simulator.
+
+**Step 2:** Extend static contracts to reject removal of finite geometry, intrinsic sizing, accessibility, Swift version, and hosted Xcode execution.
+
+**Step 3:** Run `make check` from the repository and from an external directory, then run `make xcode-test`.
+
+**Step 4:** Apply isolated hostile mutations and verify the static/XCTest gates reject them.
+
+### Task 5: Document and Land
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGES.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+
+**Step 1:** Document the modern toolchain requirement, intrinsic sizing, accessibility behavior, main-thread UIKit contract, and residual visual/device validation.
+
+**Step 2:** Scan the current tree and complete Git history for credentials without printing candidate values.
+
+**Step 3:** Push one aggregate branch, open a consolidation PR against `master`, and wait for exact-head hosted Check and CodeQL evidence.
+
+**Step 4:** Merge the aggregate PR, close PRs `#13`–`#19` as superseded, and verify the final protected branch SHA and zero open PRs.

--- a/example/SampleApp/README.md
+++ b/example/SampleApp/README.md
@@ -34,27 +34,14 @@ Look at code in ViewController.swift
       import UIKit
         import iHeartRating
 
-        class ViewController: UIViewController, HeartRatingViewDelegate {
-
-           override func viewDidLoad() {
-                super.viewDidLoad()
-                // Do any additional setup after loading the view, typically from a nib.
-            }
-
-            override func didReceiveMemoryWarning() {
-                super.didReceiveMemoryWarning()
-                // Dispose of any resources that can be recreated.
-            }
-
-            func heartRatingView(ratingView: HeartRatingView, isUpdating rating:Float) {
+        final class ViewController: UIViewController, HeartRatingViewDelegate {
+            func heartRatingView(_ ratingView: HeartRatingView, isUpdating rating: Float) {
                 // do something while (rating) has been initiated
             }
 
-            func heartRatingView(ratingView: HeartRatingView, didUpdate rating: Float) {
+            func heartRatingView(_ ratingView: HeartRatingView, didUpdate rating: Float) {
                 // do something when (rating) object has been updates
             }
-
-
         }
 
 Step 4.

--- a/example/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/example/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -389,7 +389,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -405,6 +405,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -416,6 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -427,6 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
 			};
 			name = Debug;
@@ -439,6 +442,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
 			};
 			name = Release;
@@ -450,6 +454,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleAppUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = SampleApp;
 			};
 			name = Debug;
@@ -461,6 +466,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.SampleAppUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = SampleApp;
 			};
 			name = Release;

--- a/example/SampleApp/SampleApp/AppDelegate.swift
+++ b/example/SampleApp/SampleApp/AppDelegate.swift
@@ -1,46 +1,13 @@
-//
-//  AppDelegate.swift
-//  SampleApp
-//
-//  Created by Gareth on 4/25/16.
-//  Copyright © 2016 GPJ. All rights reserved.
-//
-
 import UIKit
 
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        true
     }
-
-    func applicationWillResignActive(application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
 }
-

--- a/example/SampleApp/SampleApp/ViewController.swift
+++ b/example/SampleApp/SampleApp/ViewController.swift
@@ -1,25 +1,3 @@
-//
-//  ViewController.swift
-//  SampleApp
-//
-//  Created by Gareth on 4/25/16.
-//  Copyright © 2016 GPJ. All rights reserved.
-//
-
 import UIKit
 
-class ViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-    }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
-
-}
-
+final class ViewController: UIViewController {}

--- a/example/SampleApp/SampleAppTests/SampleAppTests.swift
+++ b/example/SampleApp/SampleAppTests/SampleAppTests.swift
@@ -1,36 +1,8 @@
-//
-//  SampleAppTests.swift
-//  SampleAppTests
-//
-//  Created by Gareth on 4/25/16.
-//  Copyright © 2016 GPJ. All rights reserved.
-//
-
 import XCTest
 @testable import SampleApp
 
-class SampleAppTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+final class SampleAppTests: XCTestCase {
+    func testViewControllerLoads() {
+        XCTAssertNotNil(ViewController().view)
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
 }

--- a/example/SampleApp/SampleAppUITests/SampleAppUITests.swift
+++ b/example/SampleApp/SampleAppUITests/SampleAppUITests.swift
@@ -1,36 +1,13 @@
-//
-//  SampleAppUITests.swift
-//  SampleAppUITests
-//
-//  Created by Gareth on 4/25/16.
-//  Copyright © 2016 GPJ. All rights reserved.
-//
-
 import XCTest
 
-class SampleAppUITests: XCTestCase {
-        
-    override func setUp() {
-        super.setUp()
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        
-        // In UI tests it is usually best to stop immediately when a failure occurs.
+final class SampleAppUITests: XCTestCase {
+    override func setUpWithError() throws {
         continueAfterFailure = false
-        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
+    }
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    func testApplicationLaunches() {
+        let application = XCUIApplication()
+        application.launch()
+        XCTAssertEqual(application.state, .runningForeground)
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
 }

--- a/iHeartRating.podspec
+++ b/iHeartRating.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "iHeartRating"
-  s.version      = "0.1.6"
+  s.version      = "0.2.0"
   s.summary      = "iHeartRating provides rating functionality for hearts or any image extends UIView"
 
   # This description is used to generate tags and improve search results.
@@ -64,7 +64,8 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "12.0"
+  s.swift_version = "5.0"
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"

--- a/iHeartRating.xcodeproj/project.pbxproj
+++ b/iHeartRating.xcodeproj/project.pbxproj
@@ -226,10 +226,11 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = iHeartRatingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.iHeartRatingTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -239,10 +240,11 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = iHeartRatingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.iHeartRatingTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -283,7 +285,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -325,7 +327,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -350,6 +352,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -367,6 +370,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.iHeartRating;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -4,6 +4,7 @@
 //
 
 import UIKit
+import Darwin
 
 @objc public protocol HeartRatingViewDelegate {
     /**
@@ -118,12 +119,15 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0) {
         didSet {
-            if minImageSize.width != minImageSize.width ||
-                minImageSize.height != minImageSize.height ||
-                minImageSize.width < 0 || minImageSize.height < 0 {
+            let widthIsInvalid = minImageSize.width != minImageSize.width ||
+                isinf(Double(minImageSize.width)) || minImageSize.width < 0
+            let heightIsInvalid = minImageSize.height != minImageSize.height ||
+                isinf(Double(minImageSize.height)) || minImageSize.height < 0
+
+            if widthIsInvalid || heightIsInvalid {
                 minImageSize = CGSize(
-                    width: minImageSize.width != minImageSize.width ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.width),
-                    height: minImageSize.height != minImageSize.height ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.height)
+                    width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width,
+                    height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height
                 )
             }
             self.setNeedsLayout()

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -118,10 +118,12 @@ public class HeartRatingView: UIView {
      */
     @IBInspectable public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0) {
         didSet {
-            if minImageSize.width < 0 || minImageSize.height < 0 {
+            if minImageSize.width != minImageSize.width ||
+                minImageSize.height != minImageSize.height ||
+                minImageSize.width < 0 || minImageSize.height < 0 {
                 minImageSize = CGSize(
-                    width: max(CGFloat(0.0), minImageSize.width),
-                    height: max(CGFloat(0.0), minImageSize.height)
+                    width: minImageSize.width != minImageSize.width ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.width),
+                    height: minImageSize.height != minImageSize.height ? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.height)
                 )
             }
             self.setNeedsLayout()

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -70,7 +70,17 @@ public class HeartRatingView: UIView {
     /**
      Sets the empty and full image view content mode.
      */
-    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit
+    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
+        didSet {
+            for imageView in self.emptyImageViews {
+                imageView.contentMode = imageContentMode
+            }
+            for imageView in self.fullImageViews {
+                imageView.contentMode = imageContentMode
+            }
+            self.setNeedsLayout()
+        }
+    }
     
     /**
      Minimum rating.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -189,6 +189,14 @@ public class HeartRatingView: UIView {
     }
     
     func refresh() {
+        if self.emptyImage == nil || self.fullImage == nil {
+            for imageView in self.fullImageViews {
+                imageView.layer.mask = nil
+                imageView.hidden = true
+            }
+            return
+        }
+
         for i in 0..<self.fullImageViews.count {
             let imageView = self.fullImageViews[i]
             

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -70,7 +70,7 @@ public class HeartRatingView: UIView {
     /**
      Sets the empty and full image view content mode.
      */
-    var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
+    public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
         didSet {
             for imageView in self.emptyImageViews {
                 imageView.contentMode = imageContentMode

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -1,447 +1,422 @@
-//
-//  HeartRatingView.swift
-//  Rating Demo
-//
-
 import UIKit
-import Darwin
 
-@objc public protocol HeartRatingViewDelegate {
-    /**
-     Returns the rating value when touch events end
-     */
-    func heartRatingView(ratingView: HeartRatingView, didUpdate rating: Float)
-    
-    /**
-     Returns the rating value as the user pans
-     */
-    optional func heartRatingView(ratingView: HeartRatingView, isUpdating rating: Float)
+@objc public protocol HeartRatingViewDelegate: AnyObject {
+    @objc(heartRatingView:didUpdate:)
+    func heartRatingView(_ ratingView: HeartRatingView, didUpdate rating: Float)
+
+    @objc(heartRatingView:isUpdating:)
+    optional func heartRatingView(_ ratingView: HeartRatingView, isUpdating rating: Float)
 }
 
-/**
- A simple rating view that can set whole, half or floating point ratings.
- */
 @IBDesignable
-public class HeartRatingView: UIView {
-    
-    // MARK: Float Rating View properties
-    
+@objcMembers
+open class HeartRatingView: UIView {
     public weak var delegate: HeartRatingViewDelegate?
-    
-    /**
-     Array of empty image views
-     */
+
     private var emptyImageViews: [UIImageView] = []
-    
-    /**
-     Array of full image views
-     */
     private var fullImageViews: [UIImageView] = []
-    
-    /**
-     Sets the empty image (e.g. a star outline)
-     */
+
     @IBInspectable public var emptyImage: UIImage? {
         didSet {
-            // Update empty image views
-            for imageView in self.emptyImageViews {
-                imageView.image = emptyImage
-            }
-            self.setNeedsLayout()
-            self.refresh()
+            emptyImageViews.forEach { $0.image = emptyImage }
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            refresh()
         }
     }
-    
-    /**
-     Sets the full image that is overlayed on top of the empty image.
-     Should be same size and shape as the empty image.
-     */
+
     @IBInspectable public var fullImage: UIImage? {
         didSet {
-            // Update full image views
-            for imageView in self.fullImageViews {
-                imageView.image = fullImage
-            }
-            self.setNeedsLayout()
-            self.refresh()
+            fullImageViews.forEach { $0.image = fullImage }
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            refresh()
         }
     }
-    
-    /**
-     Sets the empty and full image view content mode.
-     */
-    public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit {
-        didSet {
-            for imageView in self.emptyImageViews {
-                imageView.contentMode = imageContentMode
-            }
-            for imageView in self.fullImageViews {
-                imageView.contentMode = imageContentMode
-            }
-            self.setNeedsLayout()
-        }
-    }
-    
-    /**
-     Minimum rating.
-     */
-    @IBInspectable public var minRating: Int  = 0 {
-        didSet {
-            if minRating < 0 {
-                minRating = 0
-            }
-            if minRating > maxRating {
-                minRating = maxRating
-            }
 
-            self.rating = self.boundedRating(self.rating)
+    public var imageContentMode: UIView.ContentMode = .scaleAspectFit {
+        didSet {
+            emptyImageViews.forEach { $0.contentMode = imageContentMode }
+            fullImageViews.forEach { $0.contentMode = imageContentMode }
+            setNeedsLayout()
         }
     }
-    
-    /**
-     Max rating value.
-     */
+
+    @IBInspectable public var minRating: Int = 0 {
+        didSet {
+            let normalized = min(max(minRating, 0), maxRating)
+            if minRating != normalized {
+                minRating = normalized
+            }
+            rating = boundedRating(rating)
+            updateAccessibilityState()
+        }
+    }
+
     @IBInspectable public var maxRating: Int = 5 {
         didSet {
-            if maxRating < 1 {
-                maxRating = 1
+            let normalized = min(max(maxRating, 1), Self.maximumRatingCount)
+            if maxRating != normalized {
+                maxRating = normalized
             }
             if minRating > maxRating {
                 minRating = maxRating
             }
-
-            let needsRefresh = maxRating != oldValue
-            
-            if needsRefresh {
-                self.removeImageViews()
-                self.initImageViews()
-                
-                // Relayout and refresh
-                self.setNeedsLayout()
-                self.rating = self.boundedRating(self.rating)
-                self.refresh()
-            }
-        }
-    }
-    
-    /**
-     Minimum image size.
-     */
-    @IBInspectable public var minImageSize: CGSize = CGSize(width: 5.0, height: 5.0) {
-        didSet {
-            let widthIsInvalid = minImageSize.width != minImageSize.width ||
-                isinf(Double(minImageSize.width)) || minImageSize.width < 0
-            let heightIsInvalid = minImageSize.height != minImageSize.height ||
-                isinf(Double(minImageSize.height)) || minImageSize.height < 0
-
-            if widthIsInvalid || heightIsInvalid {
-                minImageSize = CGSize(
-                    width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width,
-                    height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height
-                )
-            }
-            self.setNeedsLayout()
-        }
-    }
-    
-    /**
-     Set the current rating.
-     */
-    @IBInspectable public var rating: Float = 0 {
-        didSet {
-            let nextRating = self.boundedRating(self.rating)
-            if self.rating != nextRating {
-                self.rating = nextRating
-            }
-            if rating != oldValue {
-                self.refresh()
-            }
-        }
-    }
-    
-    /**
-     Sets whether or not the rating view can be changed by panning.
-     */
-    @IBInspectable public var editable: Bool = true
-    
-    /**
-     Ratings change by 0.5. Takes priority over floatRatings property.
-     */
-    @IBInspectable public var halfRatings: Bool = false
-    
-    /**
-     Ratings change by floating point values.
-     */
-    @IBInspectable public var floatRatings: Bool = false
-    
-    /**
-     Image should twerk when tap
-     */
-    @IBInspectable public var shouldBounce: Bool = false
-    
-    
-    
-    // MARK: Initializations
-    
-    required override public init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        self.initImageViews()
-    }
-    
-    required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        
-        self.initImageViews()
-    }
-    
-    // MARK: Refresh hides or shows full images
-
-    private func boundedRating(rating: Float) -> Float {
-        if rating != rating {
-            return Float(self.minRating)
-        }
-        return min(max(rating, Float(self.minRating)), Float(self.maxRating))
-    }
-    
-    func refresh() {
-        if self.emptyImage == nil || self.fullImage == nil {
-            for imageView in self.fullImageViews {
-                imageView.layer.mask = nil
-                imageView.hidden = true
-            }
-            return
-        }
-
-        for i in 0..<self.fullImageViews.count {
-            let imageView = self.fullImageViews[i]
-            
-            if self.rating>=Float(i+1) {
-                imageView.layer.mask = nil
-                imageView.hidden = false
-                
-            }
-            else if self.rating>Float(i) && self.rating<Float(i+1) {
-                
-                // Set mask layer for full image
-                let maskLayer = CALayer()
-                maskLayer.frame = CGRectMake(0, 0, CGFloat(self.rating-Float(i))*imageView.frame.size.width, imageView.frame.size.height)
-                maskLayer.backgroundColor = UIColor.blackColor().CGColor
-                imageView.layer.mask = maskLayer
-                imageView.hidden = false
-                
-                
-            }
-            else {
-                imageView.layer.mask = nil;
-                imageView.hidden = true
-            }
-        }
-    }
-    
-    // MARK: Layout helper classes
-    
-    // Calculates the ideal ImageView size in a given CGSize
-    func sizeForImage(image: UIImage, inSize size:CGSize) -> CGSize {
-        if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0 {
-            return CGSizeZero
-        }
-
-        let imageRatio = image.size.width / image.size.height
-        let viewRatio = size.width / size.height
-        
-        if imageRatio < viewRatio {
-            let scale = size.height / image.size.height
-            let width = scale * image.size.width
-            
-            return CGSizeMake(width, size.height)
-        }
-        else {
-            let scale = size.width / image.size.width
-            let height = scale * image.size.height
-            
-            return CGSizeMake(size.width, height)
-        }
-    }
-    
-    // Override to calculate ImageView frames
-    override public func layoutSubviews() {
-        super.layoutSubviews()
-        
-        if let emptyImage = self.emptyImage {
-            let imageCount = self.emptyImageViews.count
-            if imageCount == 0 {
+            guard maxRating != oldValue else {
+                updateAccessibilityState()
                 return
             }
 
-            let layoutBounds = self.bounds
-            let desiredImageWidth = layoutBounds.size.width / CGFloat(imageCount)
-            let maxImageWidth = max(self.minImageSize.width, desiredImageWidth)
-            let maxImageHeight = max(self.minImageSize.height, layoutBounds.size.height)
-            let imageViewSize = self.sizeForImage(emptyImage, inSize: CGSizeMake(maxImageWidth, maxImageHeight))
-            let imageXOffset = imageCount > 1 ?
-                (layoutBounds.size.width - (imageViewSize.width * CGFloat(imageCount))) / CGFloat(imageCount - 1) : 0
-            
-            for i in 0..<imageCount {
-                let imageFrame = CGRectMake(
-                    layoutBounds.origin.x + (i == 0 ? 0 : CGFloat(i) * (imageXOffset + imageViewSize.width)),
-                    layoutBounds.origin.y,
-                    imageViewSize.width,
-                    imageViewSize.height
-                )
-                
-                var imageView = self.emptyImageViews[i]
-                imageView.frame = imageFrame
-                
-                imageView = self.fullImageViews[i]
-                imageView.frame = imageFrame
-                
-                
+            removeImageViews()
+            initImageViews()
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            rating = boundedRating(rating)
+            refresh()
+        }
+    }
+
+    @IBInspectable public var minImageSize: CGSize = CGSize(width: 5, height: 5) {
+        didSet {
+            let normalized = CGSize(
+                width: finiteNonnegative(minImageSize.width),
+                height: finiteNonnegative(minImageSize.height)
+            )
+            if minImageSize != normalized {
+                minImageSize = normalized
             }
-            
-            self.refresh()
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
         }
     }
-    
+
+    @IBInspectable public var rating: Float = 0 {
+        didSet {
+            let normalized = boundedRating(rating)
+            if rating != normalized {
+                rating = normalized
+            }
+            if normalized != oldValue {
+                refresh()
+            }
+            updateAccessibilityState()
+        }
+    }
+
+    @IBInspectable public var editable: Bool = true {
+        didSet {
+            updateAccessibilityState()
+        }
+    }
+
+    @IBInspectable public var halfRatings: Bool = false
+    @IBInspectable public var floatRatings: Bool = false
+    @IBInspectable public var shouldBounce: Bool = false
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        initializeControl()
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        initializeControl()
+    }
+
+    public override var intrinsicContentSize: CGSize {
+        guard let emptyImage, let fullImage else {
+            return .zero
+        }
+
+        let imageWidth = max(emptyImage.size.width, fullImage.size.width)
+        let imageHeight = max(emptyImage.size.height, fullImage.size.height)
+        let itemWidth = min(
+            max(finiteNonnegative(imageWidth), minImageSize.width),
+            Self.maximumSafeDimension
+        )
+        let itemHeight = min(
+            max(finiteNonnegative(imageHeight), minImageSize.height),
+            Self.maximumSafeDimension
+        )
+        let totalWidth = min(itemWidth * CGFloat(maxRating), Self.maximumSafeDimension)
+
+        return CGSize(width: totalWidth, height: itemHeight)
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let emptyImage else {
+            setImageFrames(.zero)
+            refresh()
+            return
+        }
+
+        let imageCount = emptyImageViews.count
+        guard imageCount > 0 else {
+            return
+        }
+
+        let layoutWidth = finiteNonnegative(bounds.width, maximum: Self.maximumSafeDimension)
+        let layoutHeight = finiteNonnegative(bounds.height, maximum: Self.maximumSafeDimension)
+        guard layoutWidth > 0, layoutHeight > 0 else {
+            setImageFrames(.zero)
+            refresh()
+            return
+        }
+
+        let desiredImageWidth = layoutWidth / CGFloat(imageCount)
+        let maximumImageWidth = min(max(minImageSize.width, desiredImageWidth), layoutWidth)
+        let maximumImageHeight = min(max(minImageSize.height, layoutHeight), layoutHeight)
+        let imageViewSize = sizeForImage(
+            emptyImage,
+            inSize: CGSize(width: maximumImageWidth, height: maximumImageHeight)
+        )
+        let usedWidth = imageViewSize.width * CGFloat(imageCount)
+        let imageXOffset = imageCount > 1
+            ? (layoutWidth - usedWidth) / CGFloat(imageCount - 1)
+            : 0
+
+        for index in 0..<imageCount {
+            let x = bounds.origin.x + CGFloat(index) * (imageXOffset + imageViewSize.width)
+            let imageFrame = CGRect(
+                x: finiteCoordinate(x, fallback: bounds.origin.x),
+                y: finiteCoordinate(bounds.origin.y, fallback: 0),
+                width: imageViewSize.width,
+                height: imageViewSize.height
+            )
+            emptyImageViews[index].frame = imageFrame
+            fullImageViews[index].frame = imageFrame
+        }
+
+        refresh()
+    }
+
+    func refresh() {
+        guard emptyImage != nil, fullImage != nil else {
+            fullImageViews.forEach {
+                $0.layer.mask = nil
+                $0.isHidden = true
+            }
+            updateAccessibilityState()
+            return
+        }
+
+        for (index, imageView) in fullImageViews.enumerated() {
+            if rating >= Float(index + 1) {
+                imageView.layer.mask = nil
+                imageView.isHidden = false
+            } else if rating > Float(index), rating < Float(index + 1) {
+                let fraction = finiteNonnegative(CGFloat(rating - Float(index)), maximum: 1)
+                let maskWidth = finiteNonnegative(
+                    fraction * finiteNonnegative(imageView.bounds.width, maximum: Self.maximumSafeDimension),
+                    maximum: Self.maximumSafeDimension
+                )
+                let maskHeight = finiteNonnegative(
+                    imageView.bounds.height,
+                    maximum: Self.maximumSafeDimension
+                )
+                let maskLayer = CALayer()
+                maskLayer.frame = CGRect(x: 0, y: 0, width: maskWidth, height: maskHeight)
+                maskLayer.backgroundColor = UIColor.black.cgColor
+                imageView.layer.mask = maskLayer
+                imageView.isHidden = false
+            } else {
+                imageView.layer.mask = nil
+                imageView.isHidden = true
+            }
+        }
+
+        updateAccessibilityState()
+    }
+
+    func sizeForImage(_ image: UIImage, inSize size: CGSize) -> CGSize {
+        let imageWidth = finiteNonnegative(image.size.width, maximum: Self.maximumSafeDimension)
+        let imageHeight = finiteNonnegative(image.size.height, maximum: Self.maximumSafeDimension)
+        let availableWidth = finiteNonnegative(size.width, maximum: Self.maximumSafeDimension)
+        let availableHeight = finiteNonnegative(size.height, maximum: Self.maximumSafeDimension)
+
+        guard imageWidth > 0, imageHeight > 0, availableWidth > 0, availableHeight > 0 else {
+            return .zero
+        }
+
+        let scale = min(availableWidth / imageWidth, availableHeight / imageHeight)
+        guard scale.isFinite, scale > 0 else {
+            return .zero
+        }
+
+        return CGSize(
+            width: min(imageWidth * scale, availableWidth),
+            height: min(imageHeight * scale, availableHeight)
+        )
+    }
+
     func removeImageViews() {
-        // Remove old image views
-        for i in 0..<self.emptyImageViews.count {
-            var imageView = self.emptyImageViews[i]
-            imageView.removeFromSuperview()
-            imageView = self.fullImageViews[i]
-            imageView.removeFromSuperview()
-        }
-        self.emptyImageViews.removeAll(keepCapacity: false)
-        self.fullImageViews.removeAll(keepCapacity: false)
+        (emptyImageViews + fullImageViews).forEach { $0.removeFromSuperview() }
+        emptyImageViews.removeAll(keepingCapacity: false)
+        fullImageViews.removeAll(keepingCapacity: false)
     }
-    
+
     func initImageViews() {
-        if self.emptyImageViews.count != 0 {
+        guard emptyImageViews.isEmpty else {
             return
         }
-        
-        // Add new image views
-        for _ in 0..<self.maxRating {
-            let emptyImageView = UIImageView()
-            emptyImageView.contentMode = self.imageContentMode
-            emptyImageView.image = self.emptyImage
-            self.emptyImageViews.append(emptyImageView)
-            self.addSubview(emptyImageView)
-            
-            let fullImageView = UIImageView()
-            fullImageView.contentMode = self.imageContentMode
-            fullImageView.image = self.fullImage
-            self.fullImageViews.append(fullImageView)
-            self.addSubview(fullImageView)
+
+        for _ in 0..<maxRating {
+            let emptyImageView = makeImageView(image: emptyImage)
+            emptyImageViews.append(emptyImageView)
+            addSubview(emptyImageView)
+
+            let fullImageView = makeImageView(image: fullImage)
+            fullImageViews.append(fullImageView)
+            addSubview(fullImageView)
         }
     }
 
-    private func bounceImageForCurrentRating() {
-        if shouldBounce && !self.fullImageViews.isEmpty {
-            let rawImageViewIndex = Int(self.rating - 1 <= 0 ? 0 : self.rating - 1)
-            let imageViewIndex = min(max(rawImageViewIndex, 0), self.fullImageViews.count - 1)
-            self.fullImageViews[imageViewIndex].transform = CGAffineTransformMakeScale(0.1, 0.1)
+    func handleTouchAtLocation(_ touchLocation: CGPoint) {
+        guard editable, emptyImage != nil, fullImage != nil, !emptyImageViews.isEmpty else {
+            return
+        }
 
-            UIView.animateWithDuration(2.0,
-                delay: 0,
-                usingSpringWithDamping: 0.2,
-                initialSpringVelocity: 9.0,
-                options: UIViewAnimationOptions.AllowUserInteraction,
-                animations: {
-                    self.fullImageViews[imageViewIndex].transform = CGAffineTransformIdentity
-                }, completion: nil)
-        }
-    }
-    
-    // MARK: Touch events
-    
-    // Calculates new rating based on touch location in view
-    func handleTouchAtLocation(touchLocation: CGPoint) {
-        if !self.editable {
-            return
-        }
-        if self.emptyImageViews.isEmpty {
-            return
-        }
-        
         var newRating: Float = 0
-        for i in (self.emptyImageViews.count-1).stride(through: 0, by: -1) {
-            let imageView = self.emptyImageViews[i]
-            if imageView.frame.size.width <= 0 {
+        for index in stride(from: emptyImageViews.count - 1, through: 0, by: -1) {
+            let imageView = emptyImageViews[index]
+            guard imageView.frame.width > 0 else {
                 continue
             }
 
             if touchLocation.x > imageView.frame.origin.x {
-                // Find touch point in image view
-                let newLocation = imageView.convertPoint(touchLocation, fromView:self)
-                
-                // Find decimal value for float or half rating
-                if imageView.pointInside(newLocation, withEvent: nil) && (self.floatRatings || self.halfRatings) {
-                    let decimalNum = Float(newLocation.x / imageView.frame.size.width)
-                    newRating = Float(i) + decimalNum
-                    if self.halfRatings {
-                        newRating = Float(i) + (decimalNum > 0.75 ? 1:(decimalNum > 0.25 ? 0.5:0))
+                let newLocation = imageView.convert(touchLocation, from: self)
+                if imageView.point(inside: newLocation, with: nil), floatRatings || halfRatings {
+                    let decimal = Float(newLocation.x / imageView.frame.width)
+                    newRating = Float(index) + decimal
+                    if halfRatings {
+                        newRating = Float(index) + (decimal > 0.75 ? 1 : (decimal > 0.25 ? 0.5 : 0))
                     }
-                }
-                    // Whole rating
-                else {
-                    newRating = Float(i) + 1.0
+                } else {
+                    newRating = Float(index) + 1
                 }
                 break
             }
         }
-        
-        self.rating = self.boundedRating(newRating)
-        
-        // Update delegate
-        if let delegate = self.delegate {
-            delegate.heartRatingView?(self, isUpdating: self.rating)
-        }
+
+        rating = boundedRating(newRating)
+        delegate?.heartRatingView?(self, isUpdating: rating)
     }
-    
-    override public func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        if !self.editable {
+
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard editable, let touch = touches.first else {
             return
         }
-        if touches.isEmpty {
+        handleTouchAtLocation(touch.location(in: self))
+    }
+
+    public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard editable, let touch = touches.first else {
+            return
+        }
+        handleTouchAtLocation(touch.location(in: self))
+    }
+
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard editable, !touches.isEmpty else {
             return
         }
 
-        if let touch = touches.first {
-            let touchLocation = touch.locationInView(self)
-            self.handleTouchAtLocation(touchLocation)
-        }
+        delegate?.heartRatingView(self, didUpdate: rating)
+        bounceImageForCurrentRating()
     }
-    
-    override public func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        if !self.editable {
+
+    public override func accessibilityIncrement() {
+        adjustRatingForAccessibility(by: 1)
+    }
+
+    public override func accessibilityDecrement() {
+        adjustRatingForAccessibility(by: -1)
+    }
+
+    private static let maximumSafeDimension = CGFloat(1_000_000)
+    private static let maximumRatingCount = 100
+
+    private func initializeControl() {
+        isAccessibilityElement = true
+        if accessibilityLabel == nil {
+            accessibilityLabel = "Rating"
+        }
+        initImageViews()
+        updateAccessibilityState()
+    }
+
+    private func makeImageView(image: UIImage?) -> UIImageView {
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = imageContentMode
+        imageView.isAccessibilityElement = false
+        return imageView
+    }
+
+    private func setImageFrames(_ frame: CGRect) {
+        emptyImageViews.forEach { $0.frame = frame }
+        fullImageViews.forEach { $0.frame = frame }
+    }
+
+    private func boundedRating(_ candidate: Float) -> Float {
+        guard candidate.isFinite else {
+            return candidate.isNaN || candidate.sign == .minus ? Float(minRating) : Float(maxRating)
+        }
+        return min(max(candidate, Float(minRating)), Float(maxRating))
+    }
+
+    private func finiteNonnegative(_ value: CGFloat, maximum: CGFloat? = nil) -> CGFloat {
+        guard value.isFinite, value >= 0 else {
+            return 0
+        }
+        if let maximum {
+            return min(value, maximum)
+        }
+        return value
+    }
+
+    private func finiteCoordinate(_ value: CGFloat, fallback: CGFloat) -> CGFloat {
+        value.isFinite ? value : fallback
+    }
+
+    private func accessibilityRatingText() -> String {
+        let ratingText = rating.rounded() == rating ? String(Int(rating)) : String(rating)
+        return "\(ratingText) of \(maxRating)"
+    }
+
+    private func updateAccessibilityState() {
+        accessibilityValue = accessibilityRatingText()
+        accessibilityTraits = editable ? [.adjustable] : [.staticText]
+    }
+
+    private func adjustRatingForAccessibility(by delta: Float) {
+        guard editable else {
             return
         }
-        if touches.isEmpty {
+        rating = boundedRating(rating + delta)
+        delegate?.heartRatingView(self, didUpdate: rating)
+        bounceImageForCurrentRating()
+    }
+
+    private func bounceImageForCurrentRating() {
+        guard shouldBounce, !fullImageViews.isEmpty else {
             return
         }
 
-        if let touch = touches.first  {
-            let touchLocation = touch.locationInView(self)
-            self.handleTouchAtLocation(touchLocation)
-        }
-    }
-    
-    override public func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        if !self.editable {
-            return
-        }
-        if touches.isEmpty {
-            return
-        }
+        let rawIndex = Int(max(rating - 1, 0))
+        let imageViewIndex = min(max(rawIndex, 0), fullImageViews.count - 1)
+        fullImageViews[imageViewIndex].transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
 
-        // Update delegate
-        if let delegate = self.delegate {
-            
-            delegate.heartRatingView(self, didUpdate: self.rating)
-        }
-
-        self.bounceImageForCurrentRating()
+        UIView.animate(
+            withDuration: 2,
+            delay: 0,
+            usingSpringWithDamping: 0.2,
+            initialSpringVelocity: 9,
+            options: [.allowUserInteraction],
+            animations: { [weak self] in
+                self?.fullImageViews[imageViewIndex].transform = .identity
+            }
+        )
     }
-    
 }

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -99,6 +99,24 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(hrv.minImageSize.height == 0)
     }
 
+    func testMinImageSizeDoesNotStayPositiveInfinity() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let infinity = CGFloat(1.0) / CGFloat(0.0)
+
+        hrv.minImageSize = CGSize(width: infinity, height: 12)
+        XCTAssert(hrv.minImageSize.width == 0)
+        XCTAssert(hrv.minImageSize.height == 12)
+    }
+
+    func testMinImageSizeDoesNotStayNegativeInfinity() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let negativeInfinity = CGFloat(-1.0) / CGFloat(0.0)
+
+        hrv.minImageSize = CGSize(width: 15, height: negativeInfinity)
+        XCTAssert(hrv.minImageSize.width == 15)
+        XCTAssert(hrv.minImageSize.height == 0)
+    }
+
     func testLayoutUsesLocalBoundsWhenViewIsScaled() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -102,6 +102,31 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
     }
 
+    func testIncompleteImagePairHidesAndRestoresFullImages() {
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        hrv.emptyImage = image
+        hrv.fullImage = image
+        hrv.rating = 0.5
+        hrv.layoutSubviews()
+
+        let firstFullImageView = hrv.subviews[1] as! UIImageView
+        XCTAssertFalse(firstFullImageView.hidden)
+        XCTAssertNotNil(firstFullImageView.layer.mask)
+
+        hrv.emptyImage = nil
+        XCTAssertTrue(firstFullImageView.hidden)
+        XCTAssertNil(firstFullImageView.layer.mask)
+
+        hrv.emptyImage = image
+        hrv.layoutSubviews()
+        XCTAssertFalse(firstFullImageView.hidden)
+        XCTAssertNotNil(firstFullImageView.layer.mask)
+    }
+
     func testTouchesEndedDoesNotNotifyWhenNotEditable() {
         let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
         let delegate = RecordingHeartRatingDelegate()

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -86,6 +86,19 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(hrv.minImageSize.height == 0)
     }
 
+    func testMinImageSizeDoesNotStayNaN() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        let nan = CGFloat(Float(0.0) / Float(0.0))
+
+        hrv.minImageSize = CGSize(width: nan, height: 12)
+        XCTAssert(hrv.minImageSize.width == 0)
+        XCTAssert(hrv.minImageSize.height == 12)
+
+        hrv.minImageSize = CGSize(width: 15, height: nan)
+        XCTAssert(hrv.minImageSize.width == 15)
+        XCTAssert(hrv.minImageSize.height == 0)
+    }
+
     func testLayoutUsesLocalBoundsWhenViewIsScaled() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -1,221 +1,249 @@
-//
-//  iHeartRatingTests.swift
-//  iHeartRatingTests
-//
-//  Created by Gareth on 7/1/16.
-//  Copyright © 2016 GPJ. All rights reserved.
-//
-
 import XCTest
 import UIKit
 
 @testable import iHeartRating
 
-class RecordingHeartRatingDelegate: NSObject, HeartRatingViewDelegate {
-    var didUpdateCount = 0
-    var isUpdatingCount = 0
+final class RecordingHeartRatingDelegate: NSObject, HeartRatingViewDelegate {
+    var didUpdateRatings: [Float] = []
+    var updatingRatings: [Float] = []
 
-    func heartRatingView(ratingView: HeartRatingView, didUpdate rating: Float) {
-        didUpdateCount += 1
+    func heartRatingView(_ ratingView: HeartRatingView, didUpdate rating: Float) {
+        didUpdateRatings.append(rating)
     }
 
-    func heartRatingView(ratingView: HeartRatingView, isUpdating rating: Float) {
-        isUpdatingCount += 1
+    func heartRatingView(_ ratingView: HeartRatingView, isUpdating rating: Float) {
+        updatingRatings.append(rating)
     }
 }
 
-class iHeartRatingTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 1000, height: 1000))
-        XCTAssert(hrv.frame.height == 1000)
-        
+final class iHeartRatingTests: XCTestCase {
+    private func image(width: CGFloat = 20, height: CGFloat = 10) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        return renderer.image { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
     }
 
-    func testMaxRatingDoesNotStayBelowOne() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.maxRating = 0
-        XCTAssert(hrv.maxRating == 1)
+    private func configuredView(frame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 20)) -> HeartRatingView {
+        let view = HeartRatingView(frame: frame)
+        let ratingImage = image()
+        view.emptyImage = ratingImage
+        view.fullImage = ratingImage
+        return view
     }
 
-    func testRatingDoesNotExceedMaxRating() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.maxRating = 3
-        hrv.rating = 9
-        XCTAssert(hrv.rating == 3)
+    private func assertFinite(_ rect: CGRect, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(rect.origin.x.isFinite, file: file, line: line)
+        XCTAssertTrue(rect.origin.y.isFinite, file: file, line: line)
+        XCTAssertTrue(rect.size.width.isFinite, file: file, line: line)
+        XCTAssertTrue(rect.size.height.isFinite, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(rect.size.width, 0, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(rect.size.height, 0, file: file, line: line)
     }
 
-    func testNaNRatingFallsBackToMinRating() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.minRating = 2
-        hrv.rating = Float(0.0) / Float(0.0)
-        XCTAssert(hrv.rating == 2)
+    func testRatingAndBoundsNormalizeInvalidValues() {
+        let view = HeartRatingView(frame: .zero)
+        view.maxRating = 0
+        XCTAssertEqual(view.maxRating, 1)
+
+        view.maxRating = 3
+        view.minRating = 5
+        XCTAssertEqual(view.minRating, 3)
+        XCTAssertEqual(view.rating, 3)
+
+        view.minRating = 2
+        view.rating = .nan
+        XCTAssertEqual(view.rating, 2)
+        view.rating = .infinity
+        XCTAssertEqual(view.rating, 3)
+        view.rating = -.infinity
+        XCTAssertEqual(view.rating, 2)
     }
 
-    func testMinRatingDoesNotExceedMaxRating() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.maxRating = 2
-        hrv.minRating = 5
-        XCTAssert(hrv.minRating == 2)
-        XCTAssert(hrv.rating == 2)
+    func testMaximumRatingCountIsBoundedBeforeAllocatingImageViews() {
+        let view = HeartRatingView(frame: .zero)
+
+        view.maxRating = 101
+
+        XCTAssertEqual(view.maxRating, 100)
+        XCTAssertEqual(view.subviews.count, 200)
     }
 
-    func testZeroSizeImageReturnsZeroSize() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let imageSize = hrv.sizeForImage(UIImage(), inSize: CGSizeZero)
-        XCTAssert(imageSize.width == 0)
-        XCTAssert(imageSize.height == 0)
+    func testMinimumImageSizeNormalizesEachInvalidDimension() {
+        let view = HeartRatingView(frame: .zero)
+        let invalidValues: [CGFloat] = [-1, .nan, .infinity, -.infinity]
+
+        for invalidValue in invalidValues {
+            view.minImageSize = CGSize(width: invalidValue, height: 12)
+            XCTAssertEqual(view.minImageSize.width, 0)
+            XCTAssertEqual(view.minImageSize.height, 12)
+
+            view.minImageSize = CGSize(width: 15, height: invalidValue)
+            XCTAssertEqual(view.minImageSize.width, 15)
+            XCTAssertEqual(view.minImageSize.height, 0)
+        }
     }
 
-    func testMinImageSizeDoesNotStayNegative() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.minImageSize = CGSize(width: -10, height: -5)
-        XCTAssert(hrv.minImageSize.width == 0)
-        XCTAssert(hrv.minImageSize.height == 0)
+    func testSizeForImageRejectsNonFiniteAndNonPositiveContainers() {
+        let view = HeartRatingView(frame: .zero)
+        let ratingImage = image()
+        let hostileSizes = [
+            CGSize(width: CGFloat.nan, height: 10),
+            CGSize(width: 10, height: CGFloat.infinity),
+            CGSize(width: -CGFloat.infinity, height: 10),
+            CGSize(width: -1, height: 10),
+            .zero
+        ]
+
+        for hostileSize in hostileSizes {
+            XCTAssertEqual(view.sizeForImage(ratingImage, inSize: hostileSize), .zero)
+        }
     }
 
-    func testMinImageSizeDoesNotStayNaN() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let nan = CGFloat(Float(0.0) / Float(0.0))
+    func testExtremeMinimumImageSizeStillProducesFiniteBoundedFrames() {
+        let view = configuredView()
+        view.minImageSize = CGSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
 
-        hrv.minImageSize = CGSize(width: nan, height: 12)
-        XCTAssert(hrv.minImageSize.width == 0)
-        XCTAssert(hrv.minImageSize.height == 12)
+        view.layoutIfNeeded()
 
-        hrv.minImageSize = CGSize(width: 15, height: nan)
-        XCTAssert(hrv.minImageSize.width == 15)
-        XCTAssert(hrv.minImageSize.height == 0)
+        XCTAssertEqual(view.subviews.count, 10)
+        for subview in view.subviews {
+            assertFinite(subview.frame)
+            XCTAssertLessThanOrEqual(subview.frame.width, view.bounds.width)
+            XCTAssertLessThanOrEqual(subview.frame.height, view.bounds.height)
+        }
     }
 
-    func testMinImageSizeDoesNotStayPositiveInfinity() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let infinity = CGFloat(1.0) / CGFloat(0.0)
+    func testRepeatedLayoutKeepsPartialMaskFiniteAndStable() {
+        let view = configuredView()
+        view.rating = 0.5
 
-        hrv.minImageSize = CGSize(width: infinity, height: 12)
-        XCTAssert(hrv.minImageSize.width == 0)
-        XCTAssert(hrv.minImageSize.height == 12)
-    }
+        view.layoutIfNeeded()
+        let fullImageView = view.subviews[1] as! UIImageView
+        let firstMaskFrame = try! XCTUnwrap(fullImageView.layer.mask?.frame)
+        assertFinite(firstMaskFrame)
 
-    func testMinImageSizeDoesNotStayNegativeInfinity() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let negativeInfinity = CGFloat(-1.0) / CGFloat(0.0)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        let secondMaskFrame = try! XCTUnwrap(fullImageView.layer.mask?.frame)
 
-        hrv.minImageSize = CGSize(width: 15, height: negativeInfinity)
-        XCTAssert(hrv.minImageSize.width == 15)
-        XCTAssert(hrv.minImageSize.height == 0)
+        XCTAssertEqual(secondMaskFrame, firstMaskFrame)
+        assertFinite(secondMaskFrame)
     }
 
     func testLayoutUsesLocalBoundsWhenViewIsScaled() {
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        let view = configuredView()
+        view.transform = CGAffineTransform(scaleX: 2, y: 2)
 
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.emptyImage = image
-        hrv.transform = CGAffineTransformMakeScale(2, 2)
-        hrv.layoutSubviews()
+        view.layoutIfNeeded()
 
-        let firstImageView = hrv.subviews.first as! UIImageView
-        XCTAssert(hrv.frame.size.width == 200)
-        XCTAssert(hrv.bounds.size.width == 100)
-        XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
+        let firstImageView = view.subviews.first as! UIImageView
+        XCTAssertEqual(view.frame.width, 200, accuracy: 0.001)
+        XCTAssertEqual(view.bounds.width, 100, accuracy: 0.001)
+        XCTAssertEqual(firstImageView.frame.width, 20, accuracy: 0.001)
     }
 
-    func testImageContentModeUpdatesExistingImageViews() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+    func testIntrinsicContentSizeTracksImagesCountAndMinimumSize() {
+        let view = HeartRatingView(frame: .zero)
+        view.emptyImage = image(width: 20, height: 10)
+        view.fullImage = image(width: 24, height: 12)
+        view.maxRating = 4
+        view.minImageSize = CGSize(width: 30, height: 16)
 
-        hrv.imageContentMode = UIViewContentMode.ScaleAspectFill
+        XCTAssertEqual(view.intrinsicContentSize.width, 120, accuracy: 0.001)
+        XCTAssertEqual(view.intrinsicContentSize.height, 16, accuracy: 0.001)
 
-        XCTAssert(hrv.subviews.count == 10)
-        for subview in hrv.subviews {
-            let imageView = subview as! UIImageView
-            XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)
+        let container = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.topAnchor.constraint(equalTo: container.topAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+        XCTAssertEqual(
+            container.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize),
+            view.intrinsicContentSize
+        )
+    }
+
+    func testIncompleteImagePairHasNoIntrinsicSizeAndHidesOverlays() {
+        let view = configuredView()
+        view.rating = 0.5
+        view.layoutIfNeeded()
+        let fullImageView = view.subviews[1] as! UIImageView
+        XCTAssertFalse(fullImageView.isHidden)
+        XCTAssertNotNil(fullImageView.layer.mask)
+
+        view.emptyImage = nil
+
+        XCTAssertEqual(view.intrinsicContentSize, .zero)
+        XCTAssertTrue(fullImageView.isHidden)
+        XCTAssertNil(fullImageView.layer.mask)
+    }
+
+    func testImageContentModePropagatesAndSurvivesImageViewReplacement() {
+        let view = HeartRatingView(frame: .zero)
+        view.imageContentMode = .scaleAspectFill
+        view.maxRating = 3
+
+        XCTAssertEqual(view.subviews.count, 6)
+        for subview in view.subviews {
+            XCTAssertEqual((subview as! UIImageView).contentMode, .scaleAspectFill)
         }
+
+        XCTAssertTrue(view.responds(to: NSSelectorFromString("setImageContentMode:")))
     }
 
-    func testIncompleteImagePairHidesAndRestoresFullImages() {
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+    func testAccessibilityStateTracksRatingAndEditability() {
+        let view = configuredView()
+        view.maxRating = 5
+        view.rating = 2.5
 
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        hrv.emptyImage = image
-        hrv.fullImage = image
-        hrv.rating = 0.5
-        hrv.layoutSubviews()
+        XCTAssertTrue(view.isAccessibilityElement)
+        XCTAssertEqual(view.accessibilityLabel, "Rating")
+        XCTAssertEqual(view.accessibilityValue, "2.5 of 5")
+        XCTAssertTrue(view.accessibilityTraits.contains(.adjustable))
 
-        let firstFullImageView = hrv.subviews[1] as! UIImageView
-        XCTAssertFalse(firstFullImageView.hidden)
-        XCTAssertNotNil(firstFullImageView.layer.mask)
+        view.editable = false
 
-        hrv.emptyImage = nil
-        XCTAssertTrue(firstFullImageView.hidden)
-        XCTAssertNil(firstFullImageView.layer.mask)
-
-        hrv.emptyImage = image
-        hrv.layoutSubviews()
-        XCTAssertFalse(firstFullImageView.hidden)
-        XCTAssertNotNil(firstFullImageView.layer.mask)
+        XCTAssertFalse(view.accessibilityTraits.contains(.adjustable))
+        XCTAssertTrue(view.accessibilityTraits.contains(.staticText))
     }
 
-    func testTouchesEndedDoesNotNotifyWhenNotEditable() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+    func testAccessibilityAdjustmentsAreBoundedAndNotifyDelegate() {
+        let view = configuredView()
         let delegate = RecordingHeartRatingDelegate()
-        hrv.delegate = delegate
-        hrv.editable = false
+        view.delegate = delegate
+        view.maxRating = 2
+        view.rating = 1
 
-        hrv.touchesEnded(Set<UITouch>(), withEvent: nil)
+        view.accessibilityIncrement()
+        view.accessibilityIncrement()
+        view.accessibilityDecrement()
 
-        XCTAssert(delegate.didUpdateCount == 0)
+        XCTAssertEqual(view.rating, 1)
+        XCTAssertEqual(delegate.didUpdateRatings, [2, 2, 1])
+        XCTAssertEqual(view.accessibilityValue, "1 of 2")
     }
 
-    func testTouchesEndedDoesNotNotifyWithoutTouches() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+    func testEmptyAndNoneditableTouchesDoNotNotify() {
+        let view = HeartRatingView(frame: .zero)
         let delegate = RecordingHeartRatingDelegate()
-        hrv.delegate = delegate
+        view.delegate = delegate
 
-        hrv.touchesEnded(Set<UITouch>(), withEvent: nil)
+        view.touchesBegan([], with: nil)
+        view.touchesMoved([], with: nil)
+        view.touchesEnded([], with: nil)
+        view.editable = false
+        view.touchesEnded([], with: nil)
 
-        XCTAssert(delegate.didUpdateCount == 0)
+        XCTAssertTrue(delegate.updatingRatings.isEmpty)
+        XCTAssertTrue(delegate.didUpdateRatings.isEmpty)
     }
-
-    func testTouchesBeganDoesNotNotifyWithoutTouches() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let delegate = RecordingHeartRatingDelegate()
-        hrv.delegate = delegate
-
-        hrv.touchesBegan(Set<UITouch>(), withEvent: nil)
-
-        XCTAssert(delegate.isUpdatingCount == 0)
-    }
-
-    func testTouchesMovedDoesNotNotifyWithoutTouches() {
-        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        let delegate = RecordingHeartRatingDelegate()
-        hrv.delegate = delegate
-
-        hrv.touchesMoved(Set<UITouch>(), withEvent: nil)
-
-        XCTAssert(delegate.isUpdatingCount == 0)
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
 }

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -133,6 +133,18 @@ class iHeartRatingTests: XCTestCase {
         XCTAssert(abs(firstImageView.frame.size.width - 20) < 0.001)
     }
 
+    func testImageContentModeUpdatesExistingImageViews() {
+        let hrv = HeartRatingView.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+
+        hrv.imageContentMode = UIViewContentMode.ScaleAspectFill
+
+        XCTAssert(hrv.subviews.count == 10)
+        for subview in hrv.subviews {
+            let imageView = subview as! UIImageView
+            XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)
+        }
+    }
+
     func testIncompleteImagePairHidesAndRestoresFullImages() {
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 20, height: 20), false, 1)
         let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,6 +23,7 @@ HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation
 NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
+NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 
 
 def require(condition, message, failures):
@@ -106,6 +107,7 @@ def main():
         "docs/plans/2026-06-10-nan-rating-boundary.md",
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
         "docs/plans/2026-06-13-incomplete-image-pair.md",
+        "docs/plans/2026-06-13-nan-min-image-size.md",
     ]
 
     for relative_path in required_files:
@@ -167,9 +169,14 @@ def main():
     require("if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0" in rating_view,
             "sizeForImage must guard zero-sized images and containers",
             failures)
-    require("if minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
+    require("minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
             "minImageSize = CGSize" in rating_view and "setNeedsLayout()" in rating_view,
             "minImageSize must be clamped to non-negative values and trigger layout",
+            failures)
+    require("minImageSize.width != minImageSize.width" in rating_view and
+            "minImageSize.height != minImageSize.height" in rating_view and
+            rating_view.count("? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.") == 2,
+            "minImageSize must normalize NaN width and height independently",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -223,6 +230,11 @@ def main():
     require("testMaxRatingDoesNotStayBelowOne" in tests and "testZeroSizeImageReturnsZeroSize" in tests and
             "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
             "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
+            "testMinImageSizeDoesNotStayNaN" in tests and
+            "CGSize(width: nan, height: 12)" in tests and
+            "CGSize(width: 15, height: nan)" in tests and
+            "XCTAssert(hrv.minImageSize.height == 12)" in tests and
+            "XCTAssert(hrv.minImageSize.width == 15)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
             "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
@@ -272,6 +284,7 @@ def main():
     nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
+    nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -287,6 +300,12 @@ def main():
             failures)
     require("incomplete image pair" in readme.lower(),
             "README must document fail-closed rendering for incomplete image pairs",
+            failures)
+    require("NaN `minImageSize` dimensions normalize independently" in readme and
+            "NaN `minImageSize` dimensions must normalize to zero" in security and
+            "Normalize NaN `minImageSize` dimensions" in vision and
+            "Normalized NaN `minImageSize` width and height independently" in changes,
+            "Docs must record NaN minimum-image-size normalization",
             failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
@@ -349,6 +368,34 @@ def main():
             "All four Make gates" in incomplete_image_plan and
             "hostile mutations" in incomplete_image_plan.lower(),
             "incomplete image pair plan must record completed status and actual verification",
+            failures)
+    nan_min_image_size_statuses = re.findall(
+        r"^status: .+$", nan_min_image_size_plan, flags=re.MULTILINE
+    )
+    nan_min_image_size_sections = nan_min_image_size_plan.split(
+        "## Verification Completed\n", 1
+    )
+    nan_min_image_size_verification = (
+        nan_min_image_size_sections[1]
+        if len(nan_min_image_size_sections) == 2 else ""
+    )
+    nan_min_image_size_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "ruby -c iHeartRating.podspec",
+        "git diff --check",
+        "Five isolated hostile mutations",
+        "Hosted macOS XCTest and CodeQL evidence",
+    )
+    require(nan_min_image_size_statuses == ["status: completed"]
+            and all(item in nan_min_image_size_verification
+                    for item in nan_min_image_size_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          nan_min_image_size_verification,
+                          re.IGNORECASE) is None,
+            "NaN minImageSize plan must record completed status and actual local verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -314,8 +314,25 @@ def main():
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
             failures)
-    require("status: completed" in bounds_layout_plan and "frame-based" in bounds_layout_plan,
-            "bounds-based image layout plan must record completed mutation verification",
+    bounds_layout_statuses = re.findall(
+        r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
+    )
+    bounds_layout_sections = bounds_layout_plan.split("## Verification Completed\n", 1)
+    bounds_layout_verification = (
+        bounds_layout_sections[1] if len(bounds_layout_sections) == 2 else ""
+    )
+    bounds_layout_required_evidence = (
+        "All four Make gates",
+        "push run `27394309114`",
+        "pull-request run `27394315070`",
+        "push run `27394330649`",
+        "CodeQL setup run `27402322718`",
+        "mutation restoring `frame`-based image sizing",
+    )
+    require(bounds_layout_statuses == ["status: completed"]
+            and all(item in bounds_layout_verification for item in bounds_layout_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b", bounds_layout_verification, re.IGNORECASE) is None,
+            "bounds-based image layout plan must record completed status and actual verification",
             failures)
     require(workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,7 @@ NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
+INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 
 
 def require(condition, message, failures):
@@ -108,6 +109,7 @@ def main():
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
         "docs/plans/2026-06-13-incomplete-image-pair.md",
         "docs/plans/2026-06-13-nan-min-image-size.md",
+        "docs/plans/2026-06-13-infinite-min-image-size.md",
     ]
 
     for relative_path in required_files:
@@ -169,14 +171,22 @@ def main():
     require("if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0" in rating_view,
             "sizeForImage must guard zero-sized images and containers",
             failures)
-    require("minImageSize.width < 0 || minImageSize.height < 0" in rating_view and
+    require("minImageSize.width < 0" in rating_view and
+            "minImageSize.height < 0" in rating_view and
             "minImageSize = CGSize" in rating_view and "setNeedsLayout()" in rating_view,
             "minImageSize must be clamped to non-negative values and trigger layout",
             failures)
     require("minImageSize.width != minImageSize.width" in rating_view and
             "minImageSize.height != minImageSize.height" in rating_view and
-            rating_view.count("? CGFloat(0.0) : max(CGFloat(0.0), minImageSize.") == 2,
+            "width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width" in rating_view and
+            "height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height" in rating_view,
             "minImageSize must normalize NaN width and height independently",
+            failures)
+    require("isinf(Double(minImageSize.width))" in rating_view and
+            "isinf(Double(minImageSize.height))" in rating_view and
+            "func testMinImageSizeDoesNotStayPositiveInfinity()" in tests and
+            "func testMinImageSizeDoesNotStayNegativeInfinity()" in tests,
+            "minImageSize must normalize infinite width and height independently",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -285,6 +295,7 @@ def main():
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
+    infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -306,6 +317,12 @@ def main():
             "Normalize NaN `minImageSize` dimensions" in vision and
             "Normalized NaN `minImageSize` width and height independently" in changes,
             "Docs must record NaN minimum-image-size normalization",
+            failures)
+    require("Infinite `minImageSize` dimensions normalize independently" in readme and
+            "Infinite `minImageSize` dimensions must normalize to zero" in security and
+            "Normalize infinite `minImageSize` dimensions" in vision and
+            "Normalized infinite `minImageSize` width and height independently" in changes,
+            "Docs must record infinite minimum-image-size normalization",
             failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
@@ -396,6 +413,33 @@ def main():
                           nan_min_image_size_verification,
                           re.IGNORECASE) is None,
             "NaN minImageSize plan must record completed status and actual local verification",
+            failures)
+    infinite_min_image_size_statuses = re.findall(
+        r"^status: .+$", infinite_min_image_size_plan, flags=re.MULTILINE
+    )
+    infinite_min_image_size_sections = infinite_min_image_size_plan.split(
+        "## Verification Completed\n", 1
+    )
+    infinite_min_image_size_verification = (
+        infinite_min_image_size_sections[1]
+        if len(infinite_min_image_size_sections) == 2 else ""
+    )
+    infinite_min_image_size_required_evidence = (
+        "All four Make gates",
+        "`xcodebuild` was",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "ruby -c iHeartRating.podspec",
+        "git diff --check",
+        "Five isolated hostile mutations",
+    )
+    require(infinite_min_image_size_statuses == ["status: completed"]
+            and all(item in infinite_min_image_size_verification
+                    for item in infinite_min_image_size_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          infinite_min_image_size_verification,
+                          re.IGNORECASE) is None,
+            "infinite minImageSize plan must record completed status and actual local verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -27,6 +27,7 @@ NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-14-image-content-mode-propagation.md"
+PUBLIC_IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-17-public-image-content-mode.md"
 
 
 def require(condition, message, failures):
@@ -114,6 +115,7 @@ def main():
         "docs/plans/2026-06-13-infinite-min-image-size.md",
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-14-image-content-mode-propagation.md",
+        "docs/plans/2026-06-17-public-image-content-mode.md",
     ]
 
     for relative_path in required_files:
@@ -191,6 +193,10 @@ def main():
             "func testMinImageSizeDoesNotStayPositiveInfinity()" in tests and
             "func testMinImageSizeDoesNotStayNegativeInfinity()" in tests,
             "minImageSize must normalize infinite width and height independently",
+            failures)
+    require("public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit" in rating_view and
+            "@IBInspectable public var imageContentMode" not in rating_view,
+            "imageContentMode must remain a public non-IBInspectable consumer API",
             failures)
     require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
             "emptyImage changes must invalidate layout before refreshing masks",
@@ -318,6 +324,7 @@ def main():
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     image_content_mode_plan = IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if IMAGE_CONTENT_MODE_PLAN.exists() else ""
+    public_image_content_mode_plan = PUBLIC_IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if PUBLIC_IMAGE_CONTENT_MODE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -510,6 +517,39 @@ def main():
                           image_content_mode_verification,
                           re.IGNORECASE) is None,
             "image content-mode propagation plan must record completed verification",
+            failures)
+    public_image_content_mode_guidance = "External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized."
+    require(all(public_image_content_mode_guidance in document for document in
+                [read("AGENTS.md"), readme, security, vision, changes]),
+            "Docs must record the public imageContentMode consumer contract",
+            failures)
+    public_image_content_mode_statuses = re.findall(
+        r"^status: .+$", public_image_content_mode_plan, flags=re.MULTILINE
+    )
+    public_image_content_mode_sections = public_image_content_mode_plan.split(
+        "## Verification Completed\n", 1
+    )
+    public_image_content_mode_verification = (
+        public_image_content_mode_sections[1]
+        if len(public_image_content_mode_sections) == 2 else ""
+    )
+    public_image_content_mode_required = (
+        "All four Make gates passed",
+        "external-directory absolute Makefile check passed from `/tmp`",
+        "`xcodebuild` was unavailable locally",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "podspec syntax checks",
+        "git diff --check",
+        "Seven isolated hostile mutations were rejected",
+    )
+    require(public_image_content_mode_statuses == ["status: completed"] and
+            all(item in public_image_content_mode_verification
+                    for item in public_image_content_mode_required) and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      public_image_content_mode_verification,
+                      re.IGNORECASE) is None,
+            "public imageContentMode plan must record completed verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
 INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 
 
 def require(condition, message, failures):
@@ -110,6 +111,7 @@ def main():
         "docs/plans/2026-06-13-incomplete-image-pair.md",
         "docs/plans/2026-06-13-nan-min-image-size.md",
         "docs/plans/2026-06-13-infinite-min-image-size.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
     ]
 
     for relative_path in required_files:
@@ -296,10 +298,17 @@ def main():
     incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
             failures)
+    require("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and '@python3 "$(ROOT)/scripts/check-baseline.py"' in makefile,
+            "Makefile must invoke the checker through the loaded checkout root", failures)
+    require("absolute Makefile path" in readme and "any working directory" in readme,
+            "README must document location-independent verification", failures)
+    require("Make verification target derive the checkout root" in changes and "external directories" in changes,
+            "CHANGES must record location-independent verification", failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "podspec" in readme and "delegate-independent bounce" in readme and "non-editable" in readme and "empty touch" in readme.lower() and "minImageSize" in readme and "image layout invalidation" in readme and "local bounds" in readme.lower(),
             "README must document static verification, build script, and podspec expectations",
             failures)
@@ -441,6 +450,12 @@ def main():
                           re.IGNORECASE) is None,
             "infinite minImageSize plan must record completed status and actual local verification",
             failures)
+    location_statuses = re.findall(r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE)
+    location_sections = location_independent_make_plan.split("## Verification Completed\n", 1)
+    location_verification = location_sections[1] if len(location_sections) == 2 else ""
+    location_required = ("Root and external-directory Make gates passed", "root-derivation mutation failed", "checker-invocation mutation failed", "plan-status mutation failed", "plan-evidence mutation failed", "documentation mutation failed")
+    require(location_statuses == ["status: completed"] and all(item in location_verification for item in location_required) and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification, re.IGNORECASE) is None,
+            "location-independent Make plan must record completed verification", failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
     )

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -1,602 +1,197 @@
 #!/usr/bin/env python3
-from pathlib import Path
+
+from __future__ import annotations
+
+import ast
 import plistlib
 import re
 import shutil
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-BASELINE_PLAN = ROOT / "docs/plans/2026-06-08-rating-baseline.md"
-MAKE_GATES_PLAN = ROOT / "docs/plans/2026-06-09-make-gate-aliases.md"
-RATING_BOUNDS_PLAN = ROOT / "docs/plans/2026-06-08-rating-bounds.md"
-BOUNCE_PLAN = ROOT / "docs/plans/2026-06-08-bounce-without-delegate.md"
-NONEDITABLE_PLAN = ROOT / "docs/plans/2026-06-09-noneditable-touch-end.md"
-EMPTY_TOUCH_PLAN = ROOT / "docs/plans/2026-06-09-empty-touch-end.md"
-MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-09-min-image-size-guard.md"
-EMPTY_TOUCH_PHASE_PLAN = ROOT / "docs/plans/2026-06-09-empty-touch-phase-guard.md"
-NONEDITABLE_TOUCH_PHASE_PLAN = ROOT / "docs/plans/2026-06-09-noneditable-touch-phase-guard.md"
-IMAGE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-09-rating-image-layout-invalidation.md"
-HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
-NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
-BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
-INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
-NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
-INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
-LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
-IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-14-image-content-mode-propagation.md"
-PUBLIC_IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-17-public-image-content-mode.md"
 
 
-def require(condition, message, failures):
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
     if not condition:
         failures.append(message)
 
 
-def read(relative_path):
-    return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
-
-
-def parse_xml(relative_path, failures):
-    try:
-        ET.parse(str(ROOT / relative_path))
-    except ET.ParseError as error:
-        failures.append(f"{relative_path} is not well-formed XML: {error}")
-
-
-def parse_plist(relative_path, failures):
-    try:
-        with (ROOT / relative_path).open("rb") as file:
-            return plistlib.load(file)
-    except Exception as error:
-        failures.append(f"{relative_path} is not a readable plist: {error}")
-        return {}
-
-
-def run(command, failures, message):
-    result = subprocess.run(
-        command,
-        cwd=str(ROOT),
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+def run(command: list[str], message: str, failures: list[str]) -> None:
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
     if result.returncode != 0:
-        failures.append(message + "\n" + (result.stderr or result.stdout).strip())
+        failures.append(f"{message}: {result.stderr.strip() or result.stdout.strip()}")
 
 
-def main():
-    failures = []
-    required_files = [
-        ".gitignore",
-        ".github/workflows/check.yml",
-        ".travis.yml",
-        "CHANGES.md",
-        "LICENSE",
-        "Makefile",
-        "README.md",
-        "SECURITY.md",
-        "VISION.md",
-        "build.sh",
-        "iHeartRating.podspec",
-        "iHeartRating/0.1.6/iHeartRating.podspec",
-        "iHeartRating.xcodeproj/project.pbxproj",
-        "iHeartRating/Info.plist",
-        "iHeartRating/iHeartRating.h",
-        "iHeartRating/iHeartRatingView.swift",
-        "iHeartRatingTests/Info.plist",
-        "iHeartRatingTests/iHeartRatingTests.swift",
-        "example/SampleApp/README.md",
-        "example/SampleApp/SampleApp.xcodeproj/project.pbxproj",
-        "example/SampleApp/SampleApp/Info.plist",
-        "example/SampleApp/SampleApp/Base.lproj/Main.storyboard",
-        "example/SampleApp/SampleApp/Base.lproj/LaunchScreen.storyboard",
-        "screenshots/heart_app_example.gif",
-        "assets/logo.png",
-        "assets/storyboard.png",
-        "docs/readme-overview.svg",
-        "docs/plans/2026-06-08-rating-baseline.md",
-        "docs/plans/2026-06-09-make-gate-aliases.md",
-        "docs/plans/2026-06-08-rating-bounds.md",
-        "docs/plans/2026-06-08-bounce-without-delegate.md",
-        "docs/plans/2026-06-09-noneditable-touch-end.md",
-        "docs/plans/2026-06-09-empty-touch-end.md",
-        "docs/plans/2026-06-09-min-image-size-guard.md",
-        "docs/plans/2026-06-09-empty-touch-phase-guard.md",
-        "docs/plans/2026-06-09-noneditable-touch-phase-guard.md",
-        "docs/plans/2026-06-09-rating-image-layout-invalidation.md",
-        "docs/plans/2026-06-10-hosted-project-validation.md",
-        "docs/plans/2026-06-10-nan-rating-boundary.md",
-        "docs/plans/2026-06-12-bounds-based-image-layout.md",
-        "docs/plans/2026-06-13-incomplete-image-pair.md",
-        "docs/plans/2026-06-13-nan-min-image-size.md",
-        "docs/plans/2026-06-13-infinite-min-image-size.md",
-        "docs/plans/2026-06-13-location-independent-make.md",
-        "docs/plans/2026-06-14-image-content-mode-propagation.md",
-        "docs/plans/2026-06-17-public-image-content-mode.md",
+def main() -> int:
+    failures: list[str] = []
+    source = read("iHeartRating/iHeartRatingView.swift")
+    tests = read("iHeartRatingTests/iHeartRatingTests.swift")
+    library_project = read("iHeartRating.xcodeproj/project.pbxproj")
+    sample_project = read("example/SampleApp/SampleApp.xcodeproj/project.pbxproj")
+    makefile = read("Makefile")
+    build_script = read("build.sh")
+    workflow = read(".github/workflows/check.yml")
+    podspec = read("iHeartRating.podspec")
+
+    require(
+        "@objcMembers" in source and "open class HeartRatingView: UIView" in source,
+        "HeartRatingView must preserve Objective-C exposure and external subclassing",
+        failures,
+    )
+    require(
+        "@objc(heartRatingView:didUpdate:)" in source
+        and "@objc(heartRatingView:isUpdating:)" in source,
+        "delegate selectors must remain stable for Objective-C consumers",
+        failures,
+    )
+    require("public weak var delegate" in source, "delegate ownership must remain weak", failures)
+    require(
+        "public var imageContentMode: UIView.ContentMode" in source
+        and source.count("$0.contentMode = imageContentMode") == 2,
+        "public image content mode must propagate to both child image sets",
+        failures,
+    )
+    require(
+        "public override var intrinsicContentSize" in source
+        and source.count("invalidateIntrinsicContentSize()") >= 4,
+        "image, count, and minimum-size changes must invalidate intrinsic sizing",
+        failures,
+    )
+    require(
+        "private func finiteNonnegative" in source
+        and "private static let maximumSafeDimension" in source
+        and "maximumImageWidth" in source
+        and "maskWidth" in source,
+        "layout and mask geometry must pass through finite bounded normalization",
+        failures,
+    )
+    require(
+        "guard emptyImage != nil, fullImage != nil" in source
+        and "layer.mask = nil" in source
+        and "isHidden = true" in source,
+        "incomplete image pairs must fail closed and clear stale masks",
+        failures,
+    )
+    require(
+        "public override func accessibilityIncrement()" in source
+        and "public override func accessibilityDecrement()" in source
+        and "accessibilityTraits = editable ? [.adjustable] : [.staticText]" in source
+        and 'accessibilityLabel = "Rating"' in source
+        and "if accessibilityLabel == nil" in source,
+        "the rating control must expose synchronized adjustable accessibility state",
+        failures,
+    )
+    require(
+        "guard editable, emptyImage != nil, fullImage != nil" in source
+        and "guard editable, let touch = touches.first" in source
+        and "guard editable, !touches.isEmpty" in source,
+        "touch handling must reject invisible, noneditable, and empty interactions",
+        failures,
+    )
+
+    required_tests = [
+        "testMinimumImageSizeNormalizesEachInvalidDimension",
+        "testMaximumRatingCountIsBoundedBeforeAllocatingImageViews",
+        "testSizeForImageRejectsNonFiniteAndNonPositiveContainers",
+        "testExtremeMinimumImageSizeStillProducesFiniteBoundedFrames",
+        "testRepeatedLayoutKeepsPartialMaskFiniteAndStable",
+        "testIntrinsicContentSizeTracksImagesCountAndMinimumSize",
+        "testIncompleteImagePairHasNoIntrinsicSizeAndHidesOverlays",
+        "testImageContentModePropagatesAndSurvivesImageViewReplacement",
+        "testAccessibilityStateTracksRatingAndEditability",
+        "testAccessibilityAdjustmentsAreBoundedAndNotifyDelegate",
     ]
+    for test_name in required_tests:
+        require(f"func {test_name}()" in tests, f"missing focused XCTest {test_name}", failures)
 
-    for relative_path in required_files:
-        require((ROOT / relative_path).is_file(), f"Required file missing: {relative_path}", failures)
+    require(
+        "private static let maximumRatingCount = 100" in source
+        and "min(max(maxRating, 1), Self.maximumRatingCount)" in source,
+        "maxRating must be bounded before child image view allocation",
+        failures,
+    )
 
-    for xml_file in [
-        "example/SampleApp/SampleApp/Base.lproj/Main.storyboard",
-        "example/SampleApp/SampleApp/Base.lproj/LaunchScreen.storyboard",
-        "docs/readme-overview.svg",
-    ]:
-        parse_xml(xml_file, failures)
+    require(library_project.count("SWIFT_VERSION = 5.0;") == 4, "library and test targets must pin Swift 5", failures)
+    require(sample_project.count("SWIFT_VERSION = 5.0;") == 6, "sample targets must pin Swift 5", failures)
+    require(
+        "IPHONEOS_DEPLOYMENT_TARGET = 9." not in library_project
+        and "IPHONEOS_DEPLOYMENT_TARGET = 9." not in sample_project,
+        "projects must not claim deployment targets unsupported by hosted Xcode",
+        failures,
+    )
+    require('s.version      = "0.2.0"' in podspec, "podspec version must distinguish the Swift 5 platform update", failures)
+    require('s.platform     = :ios, "12.0"' in podspec, "podspec must match the tested iOS deployment target", failures)
+    require('s.swift_version = "5.0"' in podspec, "podspec must declare its Swift language version", failures)
 
-    for plist_file in [
+    require("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Make targets must be location independent", failures)
+    require(
+        re.search(r"(?m)^xcode-test:\s*$", makefile) is not None
+        and '"$(ROOT)/build.sh"' in makefile,
+        "Makefile must expose the executable Xcode gate",
+        failures,
+    )
+    require("mktemp -d" in build_script and "iHeartRating-Swift.h" in build_script, "Xcode gate must clean temporary output and inspect Objective-C API", failures)
+    require("SampleApp.xcodeproj" in build_script and "iHeartRatingTests" in build_script, "Xcode gate must build the sample and run library tests", failures)
+
+    require(workflow.count("permissions:\n  contents: read") == 1, "workflow permissions must stay read-only", failures)
+    require("persist-credentials: false" in workflow, "checkout credentials must not persist", failures)
+    require("run: make check" in workflow and "run: make xcode-test" in workflow, "hosted checks must execute static and Xcode gates", failures)
+    require("timeout-minutes: 20" in workflow, "hosted Xcode execution must remain time bounded", failures)
+    require(not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", workflow), "workflow must not gain write permissions", failures)
+
+    for relative_path in [
         "iHeartRating/Info.plist",
         "iHeartRatingTests/Info.plist",
         "example/SampleApp/SampleApp/Info.plist",
         "example/SampleApp/SampleAppTests/Info.plist",
         "example/SampleApp/SampleAppUITests/Info.plist",
     ]:
-        parse_plist(plist_file, failures)
+        try:
+            with (ROOT / relative_path).open("rb") as plist_file:
+                plistlib.load(plist_file)
+        except Exception as error:
+            failures.append(f"invalid plist {relative_path}: {error}")
 
-    run(["sh", "-n", "build.sh"], failures, "build.sh must be valid POSIX shell")
+    for relative_path in [
+        "example/SampleApp/SampleApp/Base.lproj/Main.storyboard",
+        "example/SampleApp/SampleApp/Base.lproj/LaunchScreen.storyboard",
+    ]:
+        try:
+            ET.parse(ROOT / relative_path)
+        except Exception as error:
+            failures.append(f"invalid storyboard {relative_path}: {error}")
 
-    build_sh = read("build.sh")
-    require("command -v xcodebuild" in build_sh and "xcodebuild not found" in build_sh,
-            "build.sh must fail clearly when Xcode is unavailable",
-            failures)
-    require("ci_lib()" in build_sh and "function ci_lib" not in build_sh,
-            "build.sh must use POSIX function syntax",
-            failures)
-
-    rating_view = read("iHeartRating/iHeartRatingView.swift")
-    tests = read("iHeartRatingTests/iHeartRatingTests.swift")
-    refresh_body = rating_view.split("func refresh() {", 1)[1].split("// MARK: Layout helper classes", 1)[0]
-    incomplete_image_branch = re.search(
-        r"if self\.emptyImage == nil \|\| self\.fullImage == nil \{(?P<body>.*?)\n\s*return\s*\n\s*\}",
-        refresh_body,
-        re.DOTALL,
-    )
-    require(rating_view.count("let maxImageWidth =") == 1,
-            "layoutSubviews must declare maxImageWidth once",
-            failures)
-    require("if maxRating < 1" in rating_view and "maxRating = 1" in rating_view,
-            "maxRating must be clamped to a supported lower bound",
-            failures)
-    require("private func boundedRating" in rating_view and
-            "return min(max(rating, Float(self.minRating)), Float(self.maxRating))" in rating_view,
-            "rating assignments must be bounded by minRating and maxRating",
-            failures)
-    require("if rating != rating" in rating_view and "return Float(self.minRating)" in rating_view,
-            "NaN ratings must fall back to minRating before rendering or bounce indexing",
-            failures)
-    require("if minRating < 0" in rating_view and "if minRating > maxRating" in rating_view,
-            "minRating must stay non-negative and not exceed maxRating",
-            failures)
-    require("self.rating = self.boundedRating(newRating)" in rating_view,
-            "touch handling must reuse bounded rating normalization",
-            failures)
-    require("if image.size.width <= 0 || image.size.height <= 0 || size.width <= 0 || size.height <= 0" in rating_view,
-            "sizeForImage must guard zero-sized images and containers",
-            failures)
-    require("minImageSize.width < 0" in rating_view and
-            "minImageSize.height < 0" in rating_view and
-            "minImageSize = CGSize" in rating_view and "setNeedsLayout()" in rating_view,
-            "minImageSize must be clamped to non-negative values and trigger layout",
-            failures)
-    require("minImageSize.width != minImageSize.width" in rating_view and
-            "minImageSize.height != minImageSize.height" in rating_view and
-            "width: widthIsInvalid ? CGFloat(0.0) : minImageSize.width" in rating_view and
-            "height: heightIsInvalid ? CGFloat(0.0) : minImageSize.height" in rating_view,
-            "minImageSize must normalize NaN width and height independently",
-            failures)
-    require("isinf(Double(minImageSize.width))" in rating_view and
-            "isinf(Double(minImageSize.height))" in rating_view and
-            "func testMinImageSizeDoesNotStayPositiveInfinity()" in tests and
-            "func testMinImageSizeDoesNotStayNegativeInfinity()" in tests,
-            "minImageSize must normalize infinite width and height independently",
-            failures)
-    require("public var imageContentMode: UIViewContentMode = UIViewContentMode.ScaleAspectFit" in rating_view and
-            "@IBInspectable public var imageContentMode" not in rating_view,
-            "imageContentMode must remain a public non-IBInspectable consumer API",
-            failures)
-    require(re.search(r"@IBInspectable public var emptyImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
-            "emptyImage changes must invalidate layout before refreshing masks",
-            failures)
-    require(re.search(r"@IBInspectable public var fullImage: UIImage\? \{.*?didSet \{.*?self\.setNeedsLayout\(\).*?self\.refresh\(\)", rating_view, re.DOTALL),
-            "fullImage changes must invalidate layout before refreshing masks",
-            failures)
-    require("let imageCount = self.emptyImageViews.count" in rating_view and "if imageCount == 0" in rating_view,
-            "layoutSubviews must guard empty image arrays",
-            failures)
-    require("imageCount > 1 ?" in rating_view,
-            "layoutSubviews must avoid dividing by imageCount - 1 for single-rating views",
-            failures)
-    require("let layoutBounds = self.bounds" in rating_view and
-            "layoutBounds.size.width / CGFloat(imageCount)" in rating_view and
-            "max(self.minImageSize.height, layoutBounds.size.height)" in rating_view and
-            "layoutBounds.origin.x" in rating_view and "layoutBounds.origin.y" in rating_view,
-            "layoutSubviews must calculate image geometry in local bounds coordinates",
-            failures)
-    require("self.frame.size.width / CGFloat(imageCount)" not in rating_view and
-            "max(self.minImageSize.height, self.frame.size.height)" not in rating_view,
-            "layoutSubviews must not size child images from transformed frame coordinates",
-            failures)
-    require("if self.emptyImageViews.isEmpty" in rating_view,
-            "touch handling must guard empty image arrays",
-            failures)
-    require("if imageView.frame.size.width <= 0" in rating_view,
-            "touch handling must guard zero-width image frames",
-            failures)
-    require("shouldBounce && !self.fullImageViews.isEmpty" in rating_view and "min(max(rawImageViewIndex, 0), self.fullImageViews.count - 1)" in rating_view,
-            "bounce handling must clamp the animated image index",
-            failures)
-    require("private func bounceImageForCurrentRating()" in rating_view and "self.bounceImageForCurrentRating()" in rating_view,
-            "bounce handling must run independently of delegate callbacks",
-            failures)
-    require(rating_view.count("if !self.editable") >= 4,
-            "touch handling must ignore began, moved, and ended touches when the view is not editable",
-            failures)
-    require("if touches.isEmpty" in rating_view,
-            "touch handlers must ignore empty touch sets before delegate and bounce work",
-            failures)
-    require(rating_view.count("if touches.isEmpty") >= 3,
-            "touchesBegan, touchesMoved, and touchesEnded must all guard empty touch sets",
-            failures)
-    content_mode_observer = re.search(
-        r"var imageContentMode: UIViewContentMode = UIViewContentMode\.ScaleAspectFit \{(?P<body>.*?)\n    \}",
-        rating_view,
-        re.DOTALL,
-    )
-    require(content_mode_observer is not None and
-            "for imageView in self.emptyImageViews" in content_mode_observer.group("body") and
-            "for imageView in self.fullImageViews" in content_mode_observer.group("body") and
-            content_mode_observer.group("body").count("imageView.contentMode = imageContentMode") == 2 and
-            "self.setNeedsLayout()" in content_mode_observer.group("body"),
-            "imageContentMode changes must update every existing image view and request layout",
-            failures)
-    require(incomplete_image_branch is not None and
-            "for imageView in self.fullImageViews" in incomplete_image_branch.group("body") and
-            "imageView.layer.mask = nil" in incomplete_image_branch.group("body") and
-            "imageView.hidden = true" in incomplete_image_branch.group("body"),
-            "refresh must clear and hide full overlays before returning for an incomplete image pair",
-            failures)
-    require("testMaxRatingDoesNotStayBelowOne" in tests and "testZeroSizeImageReturnsZeroSize" in tests and
-            "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
-            "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
-            "testMinImageSizeDoesNotStayNaN" in tests and
-            "CGSize(width: nan, height: 12)" in tests and
-            "CGSize(width: 15, height: nan)" in tests and
-            "XCTAssert(hrv.minImageSize.height == 12)" in tests and
-            "XCTAssert(hrv.minImageSize.width == 15)" in tests and
-            "testMinImageSizeDoesNotStayNegative" in tests and
-            "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
-            "testImageContentModeUpdatesExistingImageViews" in tests and
-            "hrv.imageContentMode = UIViewContentMode.ScaleAspectFill" in tests and
-            "XCTAssert(hrv.subviews.count == 10)" in tests and
-            "XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)" in tests and
-            "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
-            "XCTAssertTrue(firstFullImageView.hidden)" in tests and
-            "XCTAssertNil(firstFullImageView.layer.mask)" in tests and
-            tests.count("XCTAssertFalse(firstFullImageView.hidden)") == 2 and
-            "CGAffineTransformMakeScale(2, 2)" in tests and
-            "hrv.bounds.size.width == 100" in tests and
-            "testTouchesEndedDoesNotNotifyWhenNotEditable" in tests and
-            "testTouchesEndedDoesNotNotifyWithoutTouches" in tests and
-            "testTouchesBeganDoesNotNotifyWithoutTouches" in tests and
-            "testTouchesMovedDoesNotNotifyWithoutTouches" in tests,
-            "unit tests must cover rating bounds, maxRating lower bound, zero-size image handling, and touch-end guards",
-            failures)
-
-    root_podspec = read("iHeartRating.podspec")
-    archived_podspec = read("iHeartRating/0.1.6/iHeartRating.podspec")
-    for name, podspec in [("iHeartRating.podspec", root_podspec), ("iHeartRating/0.1.6/iHeartRating.podspec", archived_podspec)]:
-        require('s.name         = "iHeartRating"' in podspec, f"{name} must keep the pod name", failures)
-        require('s.version      = "0.1.6"' in podspec, f"{name} must keep version 0.1.6", failures)
-        require('s.source       = { :git => "https://github.com/garethpaul/iHeartRating.git", :tag => s.version }' in podspec,
-                f"{name} must use HTTPS git source and tag by version",
-                failures)
-        require('s.social_media_url   = "https://twitter.com/gpj"' in podspec,
-                f"{name} must use HTTPS social media URL",
-                failures)
-        require('s.source_files = "iHeartRating/*.{swift}"' in podspec,
-                f"{name} must keep the Swift source glob",
-                failures)
-
-    readme = read("README.md")
-    vision = read("VISION.md")
-    security = read("SECURITY.md")
-    changes = read("CHANGES.md")
-    makefile = read("Makefile")
-    baseline_plan = BASELINE_PLAN.read_text(encoding="utf-8") if BASELINE_PLAN.exists() else ""
-    make_gates_plan = MAKE_GATES_PLAN.read_text(encoding="utf-8") if MAKE_GATES_PLAN.exists() else ""
-    rating_bounds_plan = RATING_BOUNDS_PLAN.read_text(encoding="utf-8") if RATING_BOUNDS_PLAN.exists() else ""
-    bounce_plan = BOUNCE_PLAN.read_text(encoding="utf-8") if BOUNCE_PLAN.exists() else ""
-    noneditable_plan = NONEDITABLE_PLAN.read_text(encoding="utf-8") if NONEDITABLE_PLAN.exists() else ""
-    empty_touch_plan = EMPTY_TOUCH_PLAN.read_text(encoding="utf-8") if EMPTY_TOUCH_PLAN.exists() else ""
-    min_image_size_plan = MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if MIN_IMAGE_SIZE_PLAN.exists() else ""
-    empty_touch_phase_plan = EMPTY_TOUCH_PHASE_PLAN.read_text(encoding="utf-8") if EMPTY_TOUCH_PHASE_PLAN.exists() else ""
-    noneditable_touch_phase_plan = NONEDITABLE_TOUCH_PHASE_PLAN.read_text(encoding="utf-8") if NONEDITABLE_TOUCH_PHASE_PLAN.exists() else ""
-    image_layout_plan = IMAGE_LAYOUT_PLAN.read_text(encoding="utf-8") if IMAGE_LAYOUT_PLAN.exists() else ""
-    hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
-    nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
-    bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
-    incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
-    nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
-    infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
-    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
-    image_content_mode_plan = IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if IMAGE_CONTENT_MODE_PLAN.exists() else ""
-    public_image_content_mode_plan = PUBLIC_IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if PUBLIC_IMAGE_CONTENT_MODE_PLAN.exists() else ""
-    workflow = read(".github/workflows/check.yml")
-    require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
-            "Makefile must expose lint, test, and build aliases for the local baseline",
-            failures)
-    require("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and '@python3 "$(ROOT)/scripts/check-baseline.py"' in makefile,
-            "Makefile must invoke the checker through the loaded checkout root", failures)
-    require("absolute Makefile path" in readme and "any working directory" in readme,
-            "README must document location-independent verification", failures)
-    require("Make verification target derive the checkout root" in changes and "external directories" in changes,
-            "CHANGES must record location-independent verification", failures)
-    require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "podspec" in readme and "delegate-independent bounce" in readme and "non-editable" in readme and "empty touch" in readme.lower() and "minImageSize" in readme and "image layout invalidation" in readme and "local bounds" in readme.lower(),
-            "README must document static verification, build script, and podspec expectations",
-            failures)
-    require("empty began/moved touch" in readme,
-            "README must document empty began/moved touch guards",
-            failures)
-    require("non-editable began/moved touch" in readme,
-            "README must document non-editable began/moved touch guards",
-            failures)
-    require("incomplete image pair" in readme.lower(),
-            "README must document fail-closed rendering for incomplete image pairs",
-            failures)
-    require("NaN `minImageSize` dimensions normalize independently" in readme and
-            "NaN `minImageSize` dimensions must normalize to zero" in security and
-            "Normalize NaN `minImageSize` dimensions" in vision and
-            "Normalized NaN `minImageSize` width and height independently" in changes,
-            "Docs must record NaN minimum-image-size normalization",
-            failures)
-    require("Infinite `minImageSize` dimensions normalize independently" in readme and
-            "Infinite `minImageSize` dimensions must normalize to zero" in security and
-            "Normalize infinite `minImageSize` dimensions" in vision and
-            "Normalized infinite `minImageSize` width and height independently" in changes,
-            "Docs must record infinite minimum-image-size normalization",
-            failures)
-    require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
-            "VISION must describe baseline validation for rating behavior",
-            failures)
-    require("non-editable began/moved touch" in vision,
-            "VISION must describe non-editable began/moved touch guards",
-            failures)
-    require("incomplete image pair" in vision.lower(),
-            "VISION must describe fail-closed rendering for incomplete image pairs",
-            failures)
-    require("malformed configuration" in security and "make check" in security and "non-editable" in security and "empty touch" in security.lower() and "minImageSize" in security and "image layout invalidation" in security and "local bounds" in security.lower(),
-            "SECURITY must document configuration hardening and verification",
-            failures)
-    require("incomplete image pair" in security.lower(),
-            "SECURITY must document incomplete image-pair hardening",
-            failures)
-    require("zero-size" in changes and "maxRating" in changes and "podspec" in changes and "rating bounds" in changes and "bounce" in changes and "not editable" in changes and "empty touch" in changes.lower() and "minImageSize" in changes and "image layout invalidation" in changes and "local bounds" in changes.lower() and "make lint" in changes and "make test" in changes and "make build" in changes,
-            "CHANGES must record rating edge-case, rating bounds, and podspec updates",
-            failures)
-    require("empty began/moved touch" in changes,
-            "CHANGES must record empty began/moved touch guards",
-            failures)
-    require("non-editable began/moved touch" in changes,
-            "CHANGES must record non-editable began/moved touch guards",
-            failures)
-    require("incomplete image pair" in changes.lower(),
-            "CHANGES must record incomplete image-pair rendering behavior",
-            failures)
-    content_mode_guidance = "imageContentMode changes propagate to every existing image view"
-    normalized_guidance = [
-        " ".join(document.replace("`", "").split())
-        for document in [readme, vision, security, changes, read("AGENTS.md")]
-    ]
-    require(all(content_mode_guidance in document
-                for document in normalized_guidance),
-            "project guidance must document image content-mode propagation",
-            failures)
-    require("status: completed" in baseline_plan and "status: completed" in rating_bounds_plan and "status: completed" in bounce_plan,
-            "plans must be marked completed",
-            failures)
-    require("status: completed" in make_gates_plan,
-            "make gate aliases plan must be marked completed",
-            failures)
-    require("status: completed" in noneditable_plan,
-            "non-editable touch-end plan must be marked completed",
-            failures)
-    require("status: completed" in empty_touch_plan,
-            "empty touch-end plan must be marked completed",
-            failures)
-    require("status: completed" in min_image_size_plan,
-            "min image size plan must be marked completed",
-            failures)
-    require("status: completed" in empty_touch_phase_plan,
-            "empty touch phase plan must be marked completed",
-            failures)
-    require("status: completed" in noneditable_touch_phase_plan,
-            "non-editable touch phase plan must be marked completed",
-            failures)
-    require("status: completed" in image_layout_plan,
-            "rating image layout invalidation plan must be marked completed",
-            failures)
-    require("status: completed" in hosted_validation_plan and "make check" in hosted_validation_plan,
-            "hosted project validation plan must be completed and document make check",
-            failures)
-    require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
-            "NaN rating boundary plan must be completed and document verification",
-            failures)
-    require("status: completed" in incomplete_image_plan and
-            "All four Make gates" in incomplete_image_plan and
-            "hostile mutations" in incomplete_image_plan.lower(),
-            "incomplete image pair plan must record completed status and actual verification",
-            failures)
-    nan_min_image_size_statuses = re.findall(
-        r"^status: .+$", nan_min_image_size_plan, flags=re.MULTILINE
-    )
-    nan_min_image_size_sections = nan_min_image_size_plan.split(
-        "## Verification Completed\n", 1
-    )
-    nan_min_image_size_verification = (
-        nan_min_image_size_sections[1]
-        if len(nan_min_image_size_sections) == 2 else ""
-    )
-    nan_min_image_size_required_evidence = (
-        "All four Make gates",
-        "`xcodebuild` was",
-        "python3 -m py_compile scripts/check-baseline.py",
-        "sh -n build.sh",
-        "ruby -c iHeartRating.podspec",
-        "git diff --check",
-        "Five isolated hostile mutations",
-        "Hosted macOS XCTest and CodeQL evidence",
-    )
-    require(nan_min_image_size_statuses == ["status: completed"]
-            and all(item in nan_min_image_size_verification
-                    for item in nan_min_image_size_required_evidence)
-            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
-                          nan_min_image_size_verification,
-                          re.IGNORECASE) is None,
-            "NaN minImageSize plan must record completed status and actual local verification",
-            failures)
-    infinite_min_image_size_statuses = re.findall(
-        r"^status: .+$", infinite_min_image_size_plan, flags=re.MULTILINE
-    )
-    infinite_min_image_size_sections = infinite_min_image_size_plan.split(
-        "## Verification Completed\n", 1
-    )
-    infinite_min_image_size_verification = (
-        infinite_min_image_size_sections[1]
-        if len(infinite_min_image_size_sections) == 2 else ""
-    )
-    infinite_min_image_size_required_evidence = (
-        "All four Make gates",
-        "`xcodebuild` was",
-        "python3 -m py_compile scripts/check-baseline.py",
-        "sh -n build.sh",
-        "ruby -c iHeartRating.podspec",
-        "git diff --check",
-        "Five isolated hostile mutations",
-    )
-    require(infinite_min_image_size_statuses == ["status: completed"]
-            and all(item in infinite_min_image_size_verification
-                    for item in infinite_min_image_size_required_evidence)
-            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
-                          infinite_min_image_size_verification,
-                          re.IGNORECASE) is None,
-            "infinite minImageSize plan must record completed status and actual local verification",
-            failures)
-    location_statuses = re.findall(r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE)
-    location_sections = location_independent_make_plan.split("## Verification Completed\n", 1)
-    location_verification = location_sections[1] if len(location_sections) == 2 else ""
-    location_required = ("Root and external-directory Make gates passed", "root-derivation mutation failed", "checker-invocation mutation failed", "plan-status mutation failed", "plan-evidence mutation failed", "documentation mutation failed")
-    require(location_statuses == ["status: completed"] and all(item in location_verification for item in location_required) and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification, re.IGNORECASE) is None,
-            "location-independent Make plan must record completed verification", failures)
-    image_content_mode_statuses = re.findall(
-        r"^status: .+$", image_content_mode_plan, flags=re.MULTILINE
-    )
-    image_content_mode_sections = image_content_mode_plan.split(
-        "## Verification Completed\n", 1
-    )
-    image_content_mode_verification = (
-        image_content_mode_sections[1]
-        if len(image_content_mode_sections) == 2 else ""
-    )
-    image_content_mode_required = (
-        "All four Make gates",
-        "absolute Makefile check",
-        "python3 -m py_compile scripts/check-baseline.py",
-        "sh -n build.sh",
-        "Both podspec syntax checks",
-        "Four isolated hostile mutations",
-        "git diff --check",
-    )
-    require(image_content_mode_statuses == ["status: completed"]
-            and all(item in image_content_mode_verification
-                    for item in image_content_mode_required)
-            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
-                          image_content_mode_verification,
-                          re.IGNORECASE) is None,
-            "image content-mode propagation plan must record completed verification",
-            failures)
-    public_image_content_mode_guidance = "External consumers can configure the public `imageContentMode` property while its existing observer keeps every rating image synchronized."
-    require(all(public_image_content_mode_guidance in document for document in
-                [read("AGENTS.md"), readme, security, vision, changes]),
-            "Docs must record the public imageContentMode consumer contract",
-            failures)
-    public_image_content_mode_statuses = re.findall(
-        r"^status: .+$", public_image_content_mode_plan, flags=re.MULTILINE
-    )
-    public_image_content_mode_sections = public_image_content_mode_plan.split(
-        "## Verification Completed\n", 1
-    )
-    public_image_content_mode_verification = (
-        public_image_content_mode_sections[1]
-        if len(public_image_content_mode_sections) == 2 else ""
-    )
-    public_image_content_mode_required = (
-        "All four Make gates passed",
-        "external-directory absolute Makefile check passed from `/tmp`",
-        "`xcodebuild` was unavailable locally",
-        "python3 -m py_compile scripts/check-baseline.py",
-        "sh -n build.sh",
-        "podspec syntax checks",
-        "git diff --check",
-        "Seven isolated hostile mutations were rejected",
-    )
-    require(public_image_content_mode_statuses == ["status: completed"] and
-            all(item in public_image_content_mode_verification
-                    for item in public_image_content_mode_required) and
-            re.search(r"\b(?:pending|todo|tbd|not run)\b",
-                      public_image_content_mode_verification,
-                      re.IGNORECASE) is None,
-            "public imageContentMode plan must record completed verification",
-            failures)
-    bounds_layout_statuses = re.findall(
-        r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
-    )
-    bounds_layout_sections = bounds_layout_plan.split("## Verification Completed\n", 1)
-    bounds_layout_verification = (
-        bounds_layout_sections[1] if len(bounds_layout_sections) == 2 else ""
-    )
-    bounds_layout_required_evidence = (
-        "All four Make gates",
-        "push run `27394309114`",
-        "pull-request run `27394315070`",
-        "push run `27394330649`",
-        "CodeQL setup run `27402322718`",
-        "mutation restoring `frame`-based image sizing",
-    )
-    require(bounds_layout_statuses == ["status: completed"]
-            and all(item in bounds_layout_verification for item in bounds_layout_required_evidence)
-            and re.search(r"\b(?:pending|todo|tbd|not run)\b", bounds_layout_verification, re.IGNORECASE) is None,
-            "bounds-based image layout plan must record completed status and actual verification",
-            failures)
-    require(workflow.count("permissions:\n  contents: read") == 1 and
-            not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and
-            not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", workflow),
-            "Check workflow must use one top-level read-only permissions block",
-            failures)
-    require("cancel-in-progress: true" in workflow and "runs-on: macos-15" in workflow and
-            "timeout-minutes: 10" in workflow,
-            "Check workflow must bound duplicate and long-running macOS jobs",
-            failures)
-    require(workflow.count("uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10") == 1 and
-            "persist-credentials: false" in workflow and
-            "run: make check" in workflow,
-            "Check workflow must pin one credential-free checkout and run the canonical baseline",
-            failures)
+    run(["ruby", "-c", str(ROOT / "iHeartRating.podspec")], "root podspec syntax check failed", failures)
+    run(["sh", "-n", str(ROOT / "build.sh")], "build script syntax check failed", failures)
+    try:
+        ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    except SyntaxError as error:
+        failures.append(f"baseline checker syntax check failed: {error}")
 
     if shutil.which("xcodebuild"):
-        run(["xcodebuild", "-list", "-project", "iHeartRating.xcodeproj"],
-            failures, "xcodebuild must parse iHeartRating.xcodeproj")
-        run(["xcodebuild", "-list", "-project", "example/SampleApp/SampleApp.xcodeproj"],
-            failures, "xcodebuild must parse the SampleApp project")
+        run(
+            ["xcodebuild", "-list", "-project", str(ROOT / "iHeartRating.xcodeproj")],
+            "xcodebuild could not parse iHeartRating.xcodeproj",
+            failures,
+        )
+        run(
+            ["xcodebuild", "-list", "-project", str(ROOT / "example/SampleApp/SampleApp.xcodeproj")],
+            "xcodebuild could not parse SampleApp.xcodeproj",
+            failures,
+        )
     else:
-        print("xcodebuild unavailable; static iOS baseline only.")
+        print("xcodebuild unavailable; executable iOS validation requires make xcode-test on macOS.")
 
     if failures:
-        for failure in failures:
-            print(failure, file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
         return 1
 
     print("iHeartRating baseline checks passed.")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 NAN_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-nan-min-image-size.md"
 INFINITE_MIN_IMAGE_SIZE_PLAN = ROOT / "docs/plans/2026-06-13-infinite-min-image-size.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+IMAGE_CONTENT_MODE_PLAN = ROOT / "docs/plans/2026-06-14-image-content-mode-propagation.md"
 
 
 def require(condition, message, failures):
@@ -112,6 +113,7 @@ def main():
         "docs/plans/2026-06-13-nan-min-image-size.md",
         "docs/plans/2026-06-13-infinite-min-image-size.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-14-image-content-mode-propagation.md",
     ]
 
     for relative_path in required_files:
@@ -233,6 +235,18 @@ def main():
     require(rating_view.count("if touches.isEmpty") >= 3,
             "touchesBegan, touchesMoved, and touchesEnded must all guard empty touch sets",
             failures)
+    content_mode_observer = re.search(
+        r"var imageContentMode: UIViewContentMode = UIViewContentMode\.ScaleAspectFit \{(?P<body>.*?)\n    \}",
+        rating_view,
+        re.DOTALL,
+    )
+    require(content_mode_observer is not None and
+            "for imageView in self.emptyImageViews" in content_mode_observer.group("body") and
+            "for imageView in self.fullImageViews" in content_mode_observer.group("body") and
+            content_mode_observer.group("body").count("imageView.contentMode = imageContentMode") == 2 and
+            "self.setNeedsLayout()" in content_mode_observer.group("body"),
+            "imageContentMode changes must update every existing image view and request layout",
+            failures)
     require(incomplete_image_branch is not None and
             "for imageView in self.fullImageViews" in incomplete_image_branch.group("body") and
             "imageView.layer.mask = nil" in incomplete_image_branch.group("body") and
@@ -249,6 +263,10 @@ def main():
             "XCTAssert(hrv.minImageSize.width == 15)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
+            "testImageContentModeUpdatesExistingImageViews" in tests and
+            "hrv.imageContentMode = UIViewContentMode.ScaleAspectFill" in tests and
+            "XCTAssert(hrv.subviews.count == 10)" in tests and
+            "XCTAssert(imageView.contentMode == UIViewContentMode.ScaleAspectFill)" in tests and
             "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
             "XCTAssertTrue(firstFullImageView.hidden)" in tests and
             "XCTAssertNil(firstFullImageView.layer.mask)" in tests and
@@ -299,6 +317,7 @@ def main():
     nan_min_image_size_plan = NAN_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if NAN_MIN_IMAGE_SIZE_PLAN.exists() else ""
     infinite_min_image_size_plan = INFINITE_MIN_IMAGE_SIZE_PLAN.read_text(encoding="utf-8") if INFINITE_MIN_IMAGE_SIZE_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    image_content_mode_plan = IMAGE_CONTENT_MODE_PLAN.read_text(encoding="utf-8") if IMAGE_CONTENT_MODE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -359,6 +378,15 @@ def main():
             failures)
     require("incomplete image pair" in changes.lower(),
             "CHANGES must record incomplete image-pair rendering behavior",
+            failures)
+    content_mode_guidance = "imageContentMode changes propagate to every existing image view"
+    normalized_guidance = [
+        " ".join(document.replace("`", "").split())
+        for document in [readme, vision, security, changes, read("AGENTS.md")]
+    ]
+    require(all(content_mode_guidance in document
+                for document in normalized_guidance),
+            "project guidance must document image content-mode propagation",
             failures)
     require("status: completed" in baseline_plan and "status: completed" in rating_bounds_plan and "status: completed" in bounce_plan,
             "plans must be marked completed",
@@ -456,6 +484,33 @@ def main():
     location_required = ("Root and external-directory Make gates passed", "root-derivation mutation failed", "checker-invocation mutation failed", "plan-status mutation failed", "plan-evidence mutation failed", "documentation mutation failed")
     require(location_statuses == ["status: completed"] and all(item in location_verification for item in location_required) and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification, re.IGNORECASE) is None,
             "location-independent Make plan must record completed verification", failures)
+    image_content_mode_statuses = re.findall(
+        r"^status: .+$", image_content_mode_plan, flags=re.MULTILINE
+    )
+    image_content_mode_sections = image_content_mode_plan.split(
+        "## Verification Completed\n", 1
+    )
+    image_content_mode_verification = (
+        image_content_mode_sections[1]
+        if len(image_content_mode_sections) == 2 else ""
+    )
+    image_content_mode_required = (
+        "All four Make gates",
+        "absolute Makefile check",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "Both podspec syntax checks",
+        "Four isolated hostile mutations",
+        "git diff --check",
+    )
+    require(image_content_mode_statuses == ["status: completed"]
+            and all(item in image_content_mode_verification
+                    for item in image_content_mode_required)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                          image_content_mode_verification,
+                          re.IGNORECASE) is None,
+            "image content-mode propagation plan must record completed verification",
+            failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE
     )

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -22,6 +22,7 @@ IMAGE_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-09-rating-image-layout-invalidati
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 NAN_RATING_PLAN = ROOT / "docs/plans/2026-06-10-nan-rating-boundary.md"
 BOUNDS_LAYOUT_PLAN = ROOT / "docs/plans/2026-06-12-bounds-based-image-layout.md"
+INCOMPLETE_IMAGE_PLAN = ROOT / "docs/plans/2026-06-13-incomplete-image-pair.md"
 
 
 def require(condition, message, failures):
@@ -104,6 +105,7 @@ def main():
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-nan-rating-boundary.md",
         "docs/plans/2026-06-12-bounds-based-image-layout.md",
+        "docs/plans/2026-06-13-incomplete-image-pair.md",
     ]
 
     for relative_path in required_files:
@@ -137,6 +139,12 @@ def main():
 
     rating_view = read("iHeartRating/iHeartRatingView.swift")
     tests = read("iHeartRatingTests/iHeartRatingTests.swift")
+    refresh_body = rating_view.split("func refresh() {", 1)[1].split("// MARK: Layout helper classes", 1)[0]
+    incomplete_image_branch = re.search(
+        r"if self\.emptyImage == nil \|\| self\.fullImage == nil \{(?P<body>.*?)\n\s*return\s*\n\s*\}",
+        refresh_body,
+        re.DOTALL,
+    )
     require(rating_view.count("let maxImageWidth =") == 1,
             "layoutSubviews must declare maxImageWidth once",
             failures)
@@ -206,11 +214,21 @@ def main():
     require(rating_view.count("if touches.isEmpty") >= 3,
             "touchesBegan, touchesMoved, and touchesEnded must all guard empty touch sets",
             failures)
+    require(incomplete_image_branch is not None and
+            "for imageView in self.fullImageViews" in incomplete_image_branch.group("body") and
+            "imageView.layer.mask = nil" in incomplete_image_branch.group("body") and
+            "imageView.hidden = true" in incomplete_image_branch.group("body"),
+            "refresh must clear and hide full overlays before returning for an incomplete image pair",
+            failures)
     require("testMaxRatingDoesNotStayBelowOne" in tests and "testZeroSizeImageReturnsZeroSize" in tests and
             "testRatingDoesNotExceedMaxRating" in tests and "testMinRatingDoesNotExceedMaxRating" in tests and
             "testNaNRatingFallsBackToMinRating" in tests and "Float(0.0) / Float(0.0)" in tests and
             "testMinImageSizeDoesNotStayNegative" in tests and
             "testLayoutUsesLocalBoundsWhenViewIsScaled" in tests and
+            "testIncompleteImagePairHidesAndRestoresFullImages" in tests and
+            "XCTAssertTrue(firstFullImageView.hidden)" in tests and
+            "XCTAssertNil(firstFullImageView.layer.mask)" in tests and
+            tests.count("XCTAssertFalse(firstFullImageView.hidden)") == 2 and
             "CGAffineTransformMakeScale(2, 2)" in tests and
             "hrv.bounds.size.width == 100" in tests and
             "testTouchesEndedDoesNotNotifyWhenNotEditable" in tests and
@@ -253,6 +271,7 @@ def main():
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     nan_rating_plan = NAN_RATING_PLAN.read_text(encoding="utf-8") if NAN_RATING_PLAN.exists() else ""
     bounds_layout_plan = BOUNDS_LAYOUT_PLAN.read_text(encoding="utf-8") if BOUNDS_LAYOUT_PLAN.exists() else ""
+    incomplete_image_plan = INCOMPLETE_IMAGE_PLAN.read_text(encoding="utf-8") if INCOMPLETE_IMAGE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
     require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
             "Makefile must expose lint, test, and build aliases for the local baseline",
@@ -266,14 +285,23 @@ def main():
     require("non-editable began/moved touch" in readme,
             "README must document non-editable began/moved touch guards",
             failures)
+    require("incomplete image pair" in readme.lower(),
+            "README must document fail-closed rendering for incomplete image pairs",
+            failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "rating" in vision.lower() and "bounce" in vision.lower() and "non-editable" in vision.lower() and "empty touch" in vision.lower() and "empty began/moved touch" in vision.lower() and "minImageSize" in vision and "image layout invalidation" in vision and "local bounds" in vision.lower(),
             "VISION must describe baseline validation for rating behavior",
             failures)
     require("non-editable began/moved touch" in vision,
             "VISION must describe non-editable began/moved touch guards",
             failures)
+    require("incomplete image pair" in vision.lower(),
+            "VISION must describe fail-closed rendering for incomplete image pairs",
+            failures)
     require("malformed configuration" in security and "make check" in security and "non-editable" in security and "empty touch" in security.lower() and "minImageSize" in security and "image layout invalidation" in security and "local bounds" in security.lower(),
             "SECURITY must document configuration hardening and verification",
+            failures)
+    require("incomplete image pair" in security.lower(),
+            "SECURITY must document incomplete image-pair hardening",
             failures)
     require("zero-size" in changes and "maxRating" in changes and "podspec" in changes and "rating bounds" in changes and "bounce" in changes and "not editable" in changes and "empty touch" in changes.lower() and "minImageSize" in changes and "image layout invalidation" in changes and "local bounds" in changes.lower() and "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record rating edge-case, rating bounds, and podspec updates",
@@ -283,6 +311,9 @@ def main():
             failures)
     require("non-editable began/moved touch" in changes,
             "CHANGES must record non-editable began/moved touch guards",
+            failures)
+    require("incomplete image pair" in changes.lower(),
+            "CHANGES must record incomplete image-pair rendering behavior",
             failures)
     require("status: completed" in baseline_plan and "status: completed" in rating_bounds_plan and "status: completed" in bounce_plan,
             "plans must be marked completed",
@@ -313,6 +344,11 @@ def main():
             failures)
     require("status: completed" in nan_rating_plan and "make check" in nan_rating_plan,
             "NaN rating boundary plan must be completed and document verification",
+            failures)
+    require("status: completed" in incomplete_image_plan and
+            "All four Make gates" in incomplete_image_plan and
+            "hostile mutations" in incomplete_image_plan.lower(),
+            "incomplete image pair plan must record completed status and actual verification",
             failures)
     bounds_layout_statuses = re.findall(
         r"^status: .+$", bounds_layout_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: consolidate and harden the rating control stack

### Original Description

### Summary

Consolidates PRs #13–#19 and deep-reviews the complete `HeartRatingView` surface.

- preserves complete-image rendering and public `imageContentMode` propagation
- migrates the unbuildable Swift 2 projects to Swift 5 / iOS 12
- bounds NaN, infinity, negative, zero, extreme finite geometry, and `maxRating` allocation
- adds intrinsic sizing and stable repeated-layout/mask behavior
- preserves Objective-C delegate selectors and external subclassing
- adds synchronized adjustable accessibility state and actions
- makes static checks location independent and hosted Xcode execution mandatory

## Root causes fixed

- The previous hosted gate only parsed projects; current Xcode rejected the unset Swift language version and legacy syntax.
- Finite-but-extreme minimum sizes could escape into Core Animation frame/mask geometry.
- `maxRating` eagerly allocated two image views per unbounded integer value.
- The view had no intrinsic content size and no VoiceOver element/value/actions.

### Validation

- `make check` from the repository and from `/tmp`
- `make xcode-test` on Xcode 26.0.1 / iPhone 17 Pro simulator
- 13 XCTest cases, 0 failures
- generated `iHeartRating-Swift.h` checked for `imageContentMode` and both delegate selectors
- SampleApp Swift 5 simulator build
- 8 isolated static mutations killed
- runtime geometry and accessibility mutations killed
- root podspec Ruby syntax passed; CocoaPods CLI was unavailable locally
- current-tree and full-history Gitleaks scans: 0 findings
- GitHub secret-scanning alerts: 0; open Dependabot alerts: 0

## Compatibility

- CocoaPods metadata is prepared as `0.2.0` for the Swift 5 / iOS 12 boundary.
- `heartRatingView:didUpdate:` and `heartRatingView:isUpdating:` remain stable for Objective-C consumers.
- `HeartRatingView` remains externally subclassable and its delegate remains weak.

## Residual risk

- No physical-device, spoken VoiceOver, Switch Control, Dynamic Type, or subjective image-spacing/content-mode visual pass was performed.
- The SampleApp builds but remains a minimal shell rather than a full visual integration test.
- UIKit mutation remains main-thread-only by contract.

Supersedes #13, #14, #15, #16, #17, #18, and #19 after merge.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
