### PR TITLE
Fix: protect Make root from command-line overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test xcode-test
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -131,7 +131,7 @@ def main() -> int:
     require('s.platform     = :ios, "12.0"' in podspec, "podspec must match the tested iOS deployment target", failures)
     require('s.swift_version = "5.0"' in podspec, "podspec must declare its Swift language version", failures)
 
-    require("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Make targets must be location independent", failures)
+    require("override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Make targets must be location independent", failures)
     require(
         re.search(r"(?m)^xcode-test:\s*$", makefile) is not None
         and '"$(ROOT)/build.sh"' in makefile,


### PR DESCRIPTION
## Summary

Historical closed pull request: Fix: protect Make root from command-line overrides

### Original Description

### Summary

- protect the repository-derived Make root from command-line overrides
- update the baseline's required Makefile literal to enforce that protection

### Validation

- protected root and hostile external-directory `check`, `lint`, `test`, and `build` aliases
- isolated Make-root downgrade mutation rejected by the baseline
- in-memory Python compilation, `sh -n build.sh`, `git diff --check`, and `git fsck --strict`
- checksum-verified Gitleaks 8.30.1 history and current-tree scans

## Platform Boundary

`xcodebuild` and Swift are unavailable in the local Linux environment. The hosted macOS Check workflow remains the authoritative executable iOS validation.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the rating-control correctness, Swift compatibility, testing, CI, package, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local static checks and hosted macOS/Xcode evidence are recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, package artifact, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; simulator/device interaction and downstream CocoaPods integration remain bounded by the exact-head evidence.
