### PR TITLE
Fix overlapping rating image frames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 2026-06-25T20:57:46Z — P2 correctness — cycle: constrained image spacing
+
+- Threads: inspected the default branch, open work, rating bounds, hostile
+  geometry normalization, intrinsic sizing, transformed layout, touch and
+  accessibility paths, Xcode tests, static contracts, and hosted workflow; no
+  open pull requests or issues were present.
+- Bug fixed: constrained layout now caps each rating image to its available
+  slot width, preventing oversized `minImageSize` values from producing
+  negative spacing and overlapping interactive image frames.
+- Files: `iHeartRatingView.swift`, `iHeartRatingTests.swift`,
+  `scripts/check-baseline.py`, and
+  `docs/plans/2026-06-25-constrained-rating-image-spacing.md`.
+- Validation: reproduced the missing slot-cap contract, passed the static
+  baseline, Python and shell syntax checks, and both CocoaPods spec checks.
+- Blockers: Xcode and an iOS simulator are unavailable locally; hosted macOS
+  executable tests and Objective-C header validation remain required.
+- Next: visually verify extreme intrinsic minimums in compressed stack and
+  Auto Layout containers across left-to-right and right-to-left interfaces.
+
 ## 2026-06-19
 
 - Migrated the library, tests, and SampleApp from unbuildable Swift 2 project

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ It also keeps image layout invalidation in the rating image setters so runtime
 image changes recalculate frames before masks refresh.
 Rating image geometry is calculated from the view's local bounds so transforms
 do not inflate or misalign child images.
+When a control is narrower than its intrinsic minimum, each image is capped to
+its rating slot so interactive frames remain ordered and non-overlapping.
 An incomplete image pair renders no full overlays: clearing either image hides
 filled ratings and removes stale masks until both images are configured again.
 NaN programmatic ratings fall back to `minRating` before mask rendering or
@@ -129,6 +131,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   refresh work runs.
 - Rating image layout should use local bounds rather than transformed frame
   dimensions.
+- Compressed layouts should cap images to their rating slots instead of
+  allowing oversized minimum widths to create overlapping frames.
 - An incomplete image pair should hide full overlays and clear stale masks
   until both rating images are configured.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,8 @@ Helpful reports include:
 - Runtime image changes should keep image layout invalidation before mask refreshes.
 - Transformed rating views should calculate child geometry from local bounds,
   avoiding oversized or misaligned interactive regions.
+- Constrained rating slots should cap child widths so hostile minimum sizes
+  cannot create overlapping interactive regions.
 - An incomplete image pair should hide full overlays and remove stale masks
   rather than displaying a rating without its empty-image baseline.
 - Extreme finite dimensions are bounded before multiplication or Core Animation

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
   syntax
 - Keep image layout invalidation tied to runtime rating image changes
 - Keep child image geometry in the rating view's local bounds coordinate space
+- Keep constrained rating image frames ordered and non-overlapping
 - Hide full overlays whenever an incomplete image pair is configured
 - Normalize NaN rating assignments before rendering and animation indexing
 - Normalize NaN `minImageSize` dimensions before image layout

--- a/docs/plans/2026-06-25-constrained-rating-image-spacing.md
+++ b/docs/plans/2026-06-25-constrained-rating-image-spacing.md
@@ -1,0 +1,18 @@
+# Constrained Rating Image Spacing
+
+Status: Completed
+
+## Problem
+
+When `minImageSize.width` exceeded the width available to each rating slot, layout allowed every image to grow beyond its slot and compensated with negative spacing. Adjacent rating frames could overlap even though each frame remained finite and inside the control bounds.
+
+## Change
+
+Use the per-rating slot width as the maximum image width during constrained layout. Keep `minImageSize` in intrinsic content sizing, where Auto Layout can request the preferred unconstrained size.
+
+## Verification Completed
+
+- Added XCTest coverage requiring ordered, non-overlapping empty-image frames under an oversized minimum width.
+- Added a dependency-free baseline contract for the slot-width cap and test intent.
+- Passed the static baseline, Python compilation, shell syntax, and both podspec syntax checks.
+- Local Xcode/simulator execution was unavailable; hosted macOS Xcode tests remain required before merge.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -166,7 +166,7 @@ open class HeartRatingView: UIView {
         }
 
         let desiredImageWidth = layoutWidth / CGFloat(imageCount)
-        let maximumImageWidth = min(max(minImageSize.width, desiredImageWidth), layoutWidth)
+        let maximumImageWidth = desiredImageWidth
         let maximumImageHeight = min(max(minImageSize.height, layoutHeight), layoutHeight)
         let imageViewSize = sizeForImage(
             emptyImage,

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -118,6 +118,20 @@ final class iHeartRatingTests: XCTestCase {
         }
     }
 
+    func testOversizedMinimumImageWidthDoesNotOverlapRatingFrames() {
+        let view = configuredView()
+        view.minImageSize = CGSize(width: view.bounds.width, height: 0)
+
+        view.layoutIfNeeded()
+
+        let emptyFrames = stride(from: 0, to: view.subviews.count, by: 2).map {
+            view.subviews[$0].frame
+        }
+        for index in 1..<emptyFrames.count {
+            XCTAssertGreaterThanOrEqual(emptyFrames[index].minX, emptyFrames[index - 1].maxX)
+        }
+    }
+
     func testRepeatedLayoutKeepsPartialMaskFiniteAndStable() {
         let view = configuredView()
         view.rating = 0.5

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -74,6 +74,12 @@ def main() -> int:
         failures,
     )
     require(
+        "let maximumImageWidth = desiredImageWidth" in source
+        and "testOversizedMinimumImageWidthDoesNotOverlapRatingFrames" in tests,
+        "constrained rating image frames must not overlap when minimum width exceeds a slot",
+        failures,
+    )
+    require(
         "guard emptyImage != nil, fullImage != nil" in source
         and "layer.mask = nil" in source
         and "isHidden = true" in source,


### PR DESCRIPTION
## Summary
- cap constrained rating images to their per-rating slot width
- preserve `minImageSize` as an intrinsic-content-size preference
- add XCTest and dependency-free regression contracts
- document the layout invariant and validation evidence

## Validation
- `PATH=<temporary ruby shim>:$PATH make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- `docker run --rm -v "$PWD:/workspace" -w /workspace ruby:3.3-bookworm ruby -c iHeartRating.podspec`
- `docker run --rm -v "$PWD:/workspace" -w /workspace ruby:3.3-bookworm ruby -c iHeartRating/0.1.6/iHeartRating.podspec`

Hosted macOS checks provide the required simulator XCTest, Objective-C header, and SampleApp build evidence before merge.
