### PR TITLE
Suppress accessibility updates at rating boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-25 — P2 correctness — accessibility boundary no-ops
+
+- Made accessibility increment and decrement actions true no-ops at the rating
+  boundaries so they do not send duplicate completed-update callbacks or start
+  bounce feedback when the value cannot change.
+
 ## 2026-06-25T20:57:46Z — P2 correctness — cycle: constrained image spacing
 
 - Threads: inspected the default branch, open work, rating bounds, hostile

--- a/docs/plans/2026-06-25-accessibility-boundary-noop-design.md
+++ b/docs/plans/2026-06-25-accessibility-boundary-noop-design.md
@@ -1,0 +1,23 @@
+# Accessibility Boundary No-op Design
+
+Status: Approved
+
+## Problem
+
+Accessibility increment and decrement actions clamp the requested value to the valid rating range, but they still report a completed update and start a bounce animation when the rating is already at that boundary. Consumers therefore receive a duplicate update for an action that did not change control state.
+
+## Options
+
+1. Compute the bounded candidate and return when it equals the current rating. This keeps the existing callback and animation behavior for real changes while making boundary actions true no-ops.
+2. Reassign the bounded value and separately gate the callback and animation. This produces the same visible behavior but performs unnecessary property work and obscures the no-op contract.
+3. Preserve duplicate boundary feedback. This retains compatibility with the accidental behavior but conflicts with the delegate's completed-update meaning.
+
+## Decision
+
+Use option 1. Accessibility actions only notify the delegate and bounce when they change the bounded rating. Touch handling remains unchanged because it has a separate interaction contract.
+
+## Verification
+
+- Update the focused XCTest to exercise an increment at the maximum boundary and require only changed ratings in the delegate history.
+- Extend the dependency-free baseline to require the explicit no-op guard.
+- Run the portable baseline locally and the simulator suite in hosted macOS CI.

--- a/docs/plans/2026-06-25-accessibility-boundary-noop.md
+++ b/docs/plans/2026-06-25-accessibility-boundary-noop.md
@@ -1,0 +1,21 @@
+# Accessibility Boundary No-op Implementation Plan
+
+Status: Completed
+
+## Goal
+
+Prevent accessibility increment and decrement actions from sending completed-update callbacks or bounce feedback when the bounded rating cannot change.
+
+## Tasks
+
+1. Change the accessibility regression expectation so boundary actions do not add duplicate delegate values.
+2. Add a static source contract requiring an explicit unchanged-rating guard.
+3. Compute a bounded candidate rating and return before side effects when it matches the current value.
+4. Record the behavior change in `CHANGES.md`.
+5. Run local baseline checks and hosted Xcode simulator tests.
+
+## Verification Completed
+
+- Observed the updated dependency-free contract fail before the source guard was added.
+- Updated XCTest coverage at both rating boundaries to require delegate callbacks only for changed ratings.
+- Added the explicit bounded-candidate no-op guard before callbacks and bounce feedback.

--- a/iHeartRating/iHeartRatingView.swift
+++ b/iHeartRating/iHeartRatingView.swift
@@ -394,7 +394,11 @@ open class HeartRatingView: UIView {
         guard editable else {
             return
         }
-        rating = boundedRating(rating + delta)
+        let adjustedRating = boundedRating(rating + delta)
+        guard adjustedRating != rating else {
+            return
+        }
+        rating = adjustedRating
         delegate?.heartRatingView(self, didUpdate: rating)
         bounceImageForCurrentRating()
     }

--- a/iHeartRatingTests/iHeartRatingTests.swift
+++ b/iHeartRatingTests/iHeartRatingTests.swift
@@ -230,7 +230,7 @@ final class iHeartRatingTests: XCTestCase {
         XCTAssertTrue(view.accessibilityTraits.contains(.staticText))
     }
 
-    func testAccessibilityAdjustmentsAreBoundedAndNotifyDelegate() {
+    func testAccessibilityAdjustmentsNotifyOnlyWhenRatingChanges() {
         let view = configuredView()
         let delegate = RecordingHeartRatingDelegate()
         view.delegate = delegate
@@ -240,10 +240,12 @@ final class iHeartRatingTests: XCTestCase {
         view.accessibilityIncrement()
         view.accessibilityIncrement()
         view.accessibilityDecrement()
+        view.accessibilityDecrement()
+        view.accessibilityDecrement()
 
-        XCTAssertEqual(view.rating, 1)
-        XCTAssertEqual(delegate.didUpdateRatings, [2, 2, 1])
-        XCTAssertEqual(view.accessibilityValue, "1 of 2")
+        XCTAssertEqual(view.rating, 0)
+        XCTAssertEqual(delegate.didUpdateRatings, [2, 1, 0])
+        XCTAssertEqual(view.accessibilityValue, "0 of 2")
     }
 
     func testEmptyAndNoneditableTouchesDoNotNotify() {

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -89,6 +89,9 @@ def main() -> int:
     require(
         "public override func accessibilityIncrement()" in source
         and "public override func accessibilityDecrement()" in source
+        and "let adjustedRating = boundedRating(rating + delta)" in source
+        and "guard adjustedRating != rating else" in source
+        and "rating = adjustedRating" in source
         and "accessibilityTraits = editable ? [.adjustable] : [.staticText]" in source
         and 'accessibilityLabel = "Rating"' in source
         and "if accessibilityLabel == nil" in source,
@@ -113,7 +116,7 @@ def main() -> int:
         "testIncompleteImagePairHasNoIntrinsicSizeAndHidesOverlays",
         "testImageContentModePropagatesAndSurvivesImageViewReplacement",
         "testAccessibilityStateTracksRatingAndEditability",
-        "testAccessibilityAdjustmentsAreBoundedAndNotifyDelegate",
+        "testAccessibilityAdjustmentsNotifyOnlyWhenRatingChanges",
     ]
     for test_name in required_tests:
         require(f"func {test_name}()" in tests, f"missing focused XCTest {test_name}", failures)


### PR DESCRIPTION
## Summary

- Treat bounded accessibility increment and decrement actions as no-ops.
- Avoid duplicate completed-update callbacks and bounce feedback when the rating cannot change.
- Cover both minimum and maximum boundaries in native and portable tests.

## Baseline

Accessibility adjustment at a rating boundary could still trigger update feedback and completion behavior even though the visible rating could not change.

## Improvements

- Suppress boundary updates when increment or decrement would exceed the allowed rating range.
- Preserve successful accessibility changes within bounds.
- Add minimum/maximum regression and portable static contracts.

## Validation

- The current exact head `4d13bc857c3fe32c12cb37e268d913ad2f70cb63` passed identical six-context portable matrices in two fresh clones.
- Three exact-head hosted checks succeeded, including the macOS `baseline` simulator/sample-build authority.
- No IP network operations occurred, and redacted history/current-tree secret scans found zero findings.
- Branch protection remains strict and no pull requests are open.

## Risk

- Boundary gestures now intentionally produce no callback or bounce feedback when the rating cannot change.
- Local Linux validation cannot execute Xcode or simulator tests; hosted macOS remains the native authority.

## Follow-Ups

- Keep minimum and maximum accessibility behavior covered by native XCTest and the portable baseline.
- Revalidate callback semantics if the rating range or accessibility interaction model changes.
