### PR TITLE
docs: clarify Swift package support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 2026-06-26T12:03:17Z — P3 documentation — package support boundary
+
+- Clarified that CocoaPods and direct Xcode integration are the currently
+  declared and verified distribution surfaces.
+- Documented that Swift Package Manager is not supported without a
+  `Package.swift`, resource rules, and hosted SwiftPM build evidence.
+- Retired the completed package-support clarification priority and added a
+  fail-closed baseline contract plus completed implementation plan.
+- Validation passed the static/Make gates, both podspec syntax checks, four
+  hostile documentation/manifest mutations, and `git diff --check`.
+
 ## 2026-06-25 — P2 correctness — accessibility boundary no-ops
 
 - Made accessibility increment and decrement actions true no-ops at the rating

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ sample application.
 - Run `./build.sh` when Xcode and the required simulator runtime are installed.
 - Use `example/SampleApp` for storyboard/sample-app behavior and `iHeartRating.podspec` for CocoaPods metadata review.
 
+### Package Support
+
+- CocoaPods and direct Xcode project integration are the currently declared and
+  verified distribution surfaces.
+- Swift Package Manager is not currently supported: this repository has no
+  `Package.swift`, resource declaration, or hosted SwiftPM build.
+- Adding SwiftPM support requires a focused change that defines the package
+  products/targets, handles image resources, and adds executable hosted tests.
+
 ## Testing and Verification
 
 Run the local static baseline:
@@ -159,6 +168,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   layout correctness.
 - See `docs/plans/2026-06-13-incomplete-image-pair.md` for fail-closed image-pair
   rendering.
+- See `docs/plans/2026-06-26-swift-package-support.md` for the current
+  CocoaPods/Xcode-only package boundary.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, podspecs, plist/storyboard files, or build scripts.
 

--- a/VISION.md
+++ b/VISION.md
@@ -37,12 +37,13 @@ Priority:
   local verification gates
 - Keep pinned, credential-free macOS CI running static contracts, simulator
   XCTest, Objective-C header checks, and the SampleApp build
+- Keep CocoaPods and direct Xcode integration as the only declared package
+  surfaces until a tested `Package.swift` is added in a focused change
 
 Next priorities:
 
 - Add visual regression coverage for image spacing and content modes
 - Add spoken VoiceOver and Switch Control device verification
-- Clarify Swift Package Manager support if the library is revived
 
 Contribution rules:
 

--- a/docs/plans/2026-06-26-swift-package-support.md
+++ b/docs/plans/2026-06-26-swift-package-support.md
@@ -1,0 +1,26 @@
+# Swift Package Manager Support Boundary
+
+Status: completed
+
+## Context
+
+The repository distributes the library through its Xcode project and CocoaPods
+podspecs. It does not contain a `Package.swift`, but the README did not state
+whether Swift Package Manager was supported.
+
+## Work Completed
+
+- Documented CocoaPods and direct Xcode integration as the supported surfaces.
+- Stated that Swift Package Manager is not currently declared or verified.
+- Required a focused future change to add a manifest, resource rules, and hosted verification.
+- Retired the completed roadmap clarification item.
+- Added a static contract for the documentation and absent-manifest boundary.
+
+## Verification Completed
+
+- `python3 scripts/check-baseline.py` passed.
+- `make lint`, `make test`, `make build`, and `make check` passed.
+- Both checked-in CocoaPods podspecs passed Ruby syntax validation.
+- Four focused hostile mutations were rejected across README guidance, absent
+  manifest, vision invariant, and completed-plan evidence.
+- `git diff --check` passed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -40,6 +40,31 @@ def main() -> int:
     build_script = read("build.sh")
     workflow = read(".github/workflows/check.yml")
     podspec = read("iHeartRating.podspec")
+    readme = read("README.md")
+    vision = read("VISION.md")
+    package_plan = read("docs/plans/2026-06-26-swift-package-support.md")
+
+    require(not (ROOT / "Package.swift").exists(), "unverified Package.swift must not appear without focused SwiftPM support", failures)
+    require(
+        "Swift Package Manager is not currently supported" in readme
+        and "CocoaPods and direct Xcode project integration" in readme
+        and "hosted SwiftPM build" in readme,
+        "README must document the current CocoaPods/Xcode-only package boundary",
+        failures,
+    )
+    require(
+        "Keep CocoaPods and direct Xcode integration as the only declared package" in vision
+        and "Clarify Swift Package Manager support if the library is revived" not in vision,
+        "VISION must preserve the package boundary and retire the completed clarification",
+        failures,
+    )
+    require(
+        re.search(r"(?mi)^status:\s*completed\s*$", package_plan) is not None
+        and "Verification Completed" in package_plan
+        and "Four focused hostile mutations" in package_plan,
+        "Swift package support plan must record completed verification",
+        failures,
+    )
 
     require(
         "@objcMembers" in source and "open class HeartRatingView: UIView" in source,


### PR DESCRIPTION
## Summary

- Document CocoaPods and direct Xcode integration as the currently verified package surfaces.
- State that Swift Package Manager is unsupported without a manifest, resource rules, and hosted build authority.
- Add a fail-closed package-boundary contract.

## Baseline

Project documentation could imply Swift Package Manager support even though the repository has no `Package.swift` manifest or verified SPM resource/build configuration.

## Improvements

- Describe only the CocoaPods and direct Xcode surfaces that current evidence verifies.
- Make the absence of Swift Package Manager support explicit.
- Prevent documentation from claiming SPM support until the required implementation and hosted authority exist.

## Validation

- Two fresh detached clones of `4d13bc857c3fe32c12cb37e268d913ad2f70cb63` passed identical six-context static matrices.
- Geometry, image content mode, accessibility boundaries, podspec/Xcode metadata, and non-SPM contracts passed.
- Three exact-head hosted checks succeeded, including the macOS `baseline` simulator/sample-app authority.
- No IP network operations or Gitleaks findings occurred.

## Risk

- This documentation/static-contract change intentionally narrows package claims and does not add Swift Package Manager support.
- Xcode, simulator, visual rendering, device signing, publication, uploads, and Apple services remain hosted or external boundaries.

## Follow-Ups

- Add Swift Package Manager support only with a real manifest, resource rules, tests, documentation, and hosted macOS build authority.
- Keep verified installation surfaces synchronized with repository artifacts.
