### PR TITLE
fix: preserve spaces in Makefile roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - Install dependencies: no repository-specific install command is documented.
 - Full baseline: `make check`
 - Executable iOS gate: `make xcode-test`
+- Make gates support absolute checkout paths containing spaces; preserve the encoded `MAKEFILE_LIST` root derivation and recursive regression.
 - Local Apple development: `open iHeartRating.xcodeproj`
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Install dependencies: no repository-specific install command is documented.
 - Full baseline: `make check`
 - Executable iOS gate: `make xcode-test`
-- Make gates support absolute checkout paths containing spaces; preserve the encoded `MAKEFILE_LIST` root derivation and recursive regression.
+- Make gates support absolute checkout paths containing spaces; preserve the single-Makefile authority boundary and recursive regression.
 - Local Apple development: `open iHeartRating.xcodeproj`
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+- Preserved absolute Makefile roots containing spaces and added a recursive-safe full-baseline regression.
+
 ## 2026-06-26T12:03:17Z — P3 documentation — package support boundary
 
 - Clarified that CocoaPods and direct Xcode integration are the currently

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 - Preserved absolute Makefile roots containing spaces and added a recursive-safe full-baseline regression.
+- Rejected ambiguous Makefile inputs so later recipes cannot replace verification gates.
 
 ## 2026-06-26T12:03:17Z — P3 documentation — package support boundary
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,31 @@
-.PHONY: build check lint test xcode-test
+.PHONY: __repository-make-authority build check lint test xcode-test
+.SECONDEXPANSION:
 
-override empty :=
-override space := $(empty) $(empty)
-override makefile_space := __IHEARTRATING_MAKEFILE_SPACE__
-override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
-override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell sed_path=/usr/bin/sed; [ -x "$$sed_path" ] || sed_path=/bin/sed; [ -x "$$sed_path" ] || exit 1; path=$$(printf '%s' '$(subst ','"'"',$(value MAKEFILE_LIST))' | "$$sed_path" 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile must be loaded alone)
+endif
 
-lint test build: check
+build check lint test xcode-test:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check lint test xcode-test:: $$(if $$(shell sed_path=/usr/bin/sed && [ -x "$$$$sed_path" ] || sed_path=/bin/sed && [ -x "$$$$sed_path" ] && path=$$$$(printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | "$$$$sed_path" 's/^ //') && [ -f "$$$$path" ] && printf '%s' ok),,$$(error repository Makefile must be loaded alone))
+build check lint test xcode-test:: __repository-make-authority
 
-xcode-test:
+__repository-make-authority::
+	@:
+
+lint test build:: check
+
+xcode-test::
 	@"$(ROOT)/build.sh"
 
-check:
+check::
 	@python3 "$(ROOT)/scripts/check-baseline.py"
 	@python3 "$(ROOT)/scripts/test-make-spaced-path.py"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: build check lint test xcode-test
 
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override empty :=
+override space := $(empty) $(empty)
+override makefile_space := __IHEARTRATING_MAKEFILE_SPACE__
+override encoded_makefile_list := $(patsubst $(makefile_space)%,%,$(subst $(space),$(makefile_space),$(MAKEFILE_LIST)))
+override ROOT := $(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))
 
 lint test build: check
 
@@ -9,3 +13,4 @@ xcode-test:
 
 check:
 	@python3 "$(ROOT)/scripts/check-baseline.py"
+	@python3 "$(ROOT)/scripts/test-make-spaced-path.py"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 ## Maintenance Notes
 
 - Every Make verification target derives the checkout root from the loaded
-  Makefile, so an absolute Makefile path works from any working directory.
+  Makefile, so an absolute Makefile path works from any working directory,
+  including checkout paths containing spaces.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -10,7 +10,7 @@ path containing spaces before deriving the checkout root.
 
 ## Scope
 
-1. Derive the checkout root from an encoded `MAKEFILE_LIST` that preserves spaces.
+1. Derive the checkout root from the single loaded Makefile path while preserving spaces.
 2. Invoke the Python checker through its rooted path.
 3. Add completed-plan, external-run, recursive spaced-path, guidance, and mutation contracts.
 4. Preserve Swift, tests, project, podspec, build script, and workflow files.
@@ -24,9 +24,8 @@ path containing spaces before deriving the checkout root.
 
 ## Work Completed
 
-- Derived the checkout root from the loaded Makefile and invoked the checker
-  through its absolute path while preserving spaces and command-line override
-  resistance.
+- Derived the checkout root from the sole loaded Makefile and invoked the
+  checker through its absolute path while rejecting ambiguous Makefile inputs.
 - Added a recursive-safe full-baseline regression against a copied checkout
   whose absolute path contains spaces.
 - Added rooted invocation, completed-plan evidence, and synchronized guidance.
@@ -36,6 +35,7 @@ path containing spaces before deriving the checkout root.
 
 - Root and external-directory Make gates passed for all four aliases.
 - GNU Make 4.2 and 4.4 space-containing absolute Makefile paths passed.
+- Preloaded, overridden, additional, and recipe-replacement Makefiles failed closed.
 - The root-derivation mutation failed.
 - The checker-invocation mutation failed.
 - The plan-status mutation failed.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -5,13 +5,14 @@ status: completed
 ## Context
 
 Absolute Makefile invocations resolve the maintained checker relative to the
-caller instead of the checkout.
+caller instead of the checkout. GNU Make also splits a loaded absolute Makefile
+path containing spaces before deriving the checkout root.
 
 ## Scope
 
-1. Derive the checkout root from `MAKEFILE_LIST`.
+1. Derive the checkout root from an encoded `MAKEFILE_LIST` that preserves spaces.
 2. Invoke the Python checker through its rooted path.
-3. Add completed-plan, external-run, guidance, and mutation contracts.
+3. Add completed-plan, external-run, recursive spaced-path, guidance, and mutation contracts.
 4. Preserve Swift, tests, project, podspec, build script, and workflow files.
 
 ## Verification Plan
@@ -24,13 +25,17 @@ caller instead of the checkout.
 ## Work Completed
 
 - Derived the checkout root from the loaded Makefile and invoked the checker
-  through its absolute path.
+  through its absolute path while preserving spaces and command-line override
+  resistance.
+- Added a recursive-safe full-baseline regression against a copied checkout
+  whose absolute path contains spaces.
 - Added rooted invocation, completed-plan evidence, and synchronized guidance.
 - Preserved Swift, tests, project, podspec, build script, and workflow files.
 
 ## Verification Completed
 
 - Root and external-directory Make gates passed for all four aliases.
+- GNU Make 4.2 and 4.4 space-containing absolute Makefile paths passed.
 - The root-derivation mutation failed.
 - The checker-invocation mutation failed.
 - The plan-status mutation failed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -169,11 +169,12 @@ def main() -> int:
     require('s.swift_version = "5.0"' in podspec, "podspec must declare its Swift language version", failures)
 
     require(
-        "override makefile_space := __IHEARTRATING_MAKEFILE_SPACE__" in makefile
-        and "$(subst $(space),$(makefile_space),$(MAKEFILE_LIST))" in makefile
-        and "$(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))" in makefile
+        "MAKEFILES must be empty" in makefile
+        and "MAKEFILE_LIST must not be overridden" in makefile
+        and "repository Makefile must be loaded alone" in makefile
+        and ".SECONDEXPANSION:" in makefile
         and '@python3 "$(ROOT)/scripts/test-make-spaced-path.py"' in makefile,
-        "Make targets must preserve spaces while deriving and testing the checkout root",
+        "Make targets must preserve spaces and reject ambiguous verification roots",
         failures,
     )
     require((ROOT / "scripts/test-make-spaced-path.py").is_file(), "spaced-path Make regression must remain tracked", failures)
@@ -194,7 +195,7 @@ def main() -> int:
         failures,
     )
     require(
-        re.search(r"(?m)^xcode-test:\s*$", makefile) is not None
+        re.search(r"(?m)^xcode-test::\s*$", makefile) is not None
         and '"$(ROOT)/build.sh"' in makefile,
         "Makefile must expose the executable Xcode gate",
         failures,

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -41,8 +41,11 @@ def main() -> int:
     workflow = read(".github/workflows/check.yml")
     podspec = read("iHeartRating.podspec")
     readme = read("README.md")
+    changes = read("CHANGES.md")
+    agents = read("AGENTS.md")
     vision = read("VISION.md")
     package_plan = read("docs/plans/2026-06-26-swift-package-support.md")
+    location_plan = read("docs/plans/2026-06-13-location-independent-make.md")
 
     require(not (ROOT / "Package.swift").exists(), "unverified Package.swift must not appear without focused SwiftPM support", failures)
     require(
@@ -165,7 +168,31 @@ def main() -> int:
     require('s.platform     = :ios, "12.0"' in podspec, "podspec must match the tested iOS deployment target", failures)
     require('s.swift_version = "5.0"' in podspec, "podspec must declare its Swift language version", failures)
 
-    require("override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Make targets must be location independent", failures)
+    require(
+        "override makefile_space := __IHEARTRATING_MAKEFILE_SPACE__" in makefile
+        and "$(subst $(space),$(makefile_space),$(MAKEFILE_LIST))" in makefile
+        and "$(subst $(makefile_space),$(space),$(abspath $(dir $(lastword $(encoded_makefile_list)))))" in makefile
+        and '@python3 "$(ROOT)/scripts/test-make-spaced-path.py"' in makefile,
+        "Make targets must preserve spaces while deriving and testing the checkout root",
+        failures,
+    )
+    require((ROOT / "scripts/test-make-spaced-path.py").is_file(), "spaced-path Make regression must remain tracked", failures)
+    require(
+        "paths containing spaces" in readme
+        and "absolute checkout paths containing spaces" in agents
+        and "roots containing spaces" in changes,
+        "operator guidance must document space-safe Make verification",
+        failures,
+    )
+    location_verification = location_plan.split("## Verification Completed\n", 1)
+    require(
+        re.findall(r"^status: .+$", location_plan, flags=re.MULTILINE) == ["status: completed"]
+        and len(location_verification) == 2
+        and "space-containing absolute Makefile paths passed" in location_verification[1]
+        and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_verification[1], re.IGNORECASE) is None,
+        "location-independent Make plan must record completed spaced-path verification",
+        failures,
+    )
     require(
         re.search(r"(?m)^xcode-test:\s*$", makefile) is not None
         and '"$(ROOT)/build.sh"' in makefile,

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHILD_MARKER = "IHEARTRATING_MAKE_SPACE_CHILD"
+
+
+def main():
+    if os.environ.get(CHILD_MARKER) == "1":
+        return
+
+    tracked = subprocess.check_output(
+        ["git", "-C", str(ROOT), "ls-files", "-z"]
+    ).decode().rstrip("\0").split("\0")
+    with tempfile.TemporaryDirectory(prefix="iheartrating-make-space-") as temporary:
+        root = Path(temporary)
+        copied = root / "repository with spaces"
+        caller = root / "external caller"
+        shutil.copytree(
+            ROOT,
+            copied,
+            ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "*.pyo"),
+        )
+        caller.mkdir()
+        subprocess.run(["git", "-C", copied, "init", "-q"], check=True)
+        subprocess.run(
+            ["git", "-C", copied, "add", "-f", "-N", "--", *tracked],
+            check=True,
+        )
+        environment = os.environ.copy()
+        environment[CHILD_MARKER] = "1"
+        subprocess.run(
+            [environment.get("IHEARTRATING_MAKE", "make"), "-f", str(copied / "Makefile"), "check"],
+            cwd=caller,
+            env=environment,
+            check=True,
+            timeout=180,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-make-spaced-path.py
+++ b/scripts/test-make-spaced-path.py
@@ -10,6 +10,18 @@ ROOT = Path(__file__).resolve().parents[1]
 CHILD_MARKER = "IHEARTRATING_MAKE_SPACE_CHILD"
 
 
+def run_make(make, arguments, caller, environment):
+    return subprocess.run(
+        [make, *arguments],
+        cwd=caller,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=180,
+    )
+
+
 def main():
     if os.environ.get(CHILD_MARKER) == "1":
         return
@@ -34,13 +46,51 @@ def main():
         )
         environment = os.environ.copy()
         environment[CHILD_MARKER] = "1"
+        make = environment.get("IHEARTRATING_MAKE", "make")
+        repository_makefile = str(copied / "Makefile")
         subprocess.run(
-            [environment.get("IHEARTRATING_MAKE", "make"), "-f", str(copied / "Makefile"), "check"],
+            [make, "-f", repository_makefile, "check"],
             cwd=caller,
             env=environment,
             check=True,
             timeout=180,
         )
+
+        extra_makefile = root / "extra.mk"
+        extra_makefile.write_text(".PHONY: extra\nextra:\n\t@:\n", encoding="utf-8")
+        replacement_makefile = root / "replacement.mk"
+        replacement_makefile.write_text(
+            ".PHONY: check xcode-test\ncheck xcode-test:\n\t@echo BYPASSED\n",
+            encoding="utf-8",
+        )
+
+        preload_environment = environment.copy()
+        preload_environment["MAKEFILES"] = str(extra_makefile)
+        preload = run_make(make, ["-f", repository_makefile, "check"], caller, preload_environment)
+        if preload.returncode == 0 or "MAKEFILES must be empty" not in preload.stderr:
+            raise RuntimeError("MAKEFILES preload must fail closed")
+
+        overridden = run_make(make, ["-f", repository_makefile, "MAKEFILE_LIST=untrusted", "check"], caller, environment)
+        if overridden.returncode == 0 or "MAKEFILE_LIST must not be overridden" not in overridden.stderr:
+            raise RuntimeError("MAKEFILE_LIST override must fail closed")
+
+        for arguments in (
+            ["-f", str(extra_makefile), "-f", repository_makefile, "check"],
+            ["-f", repository_makefile, "-f", str(extra_makefile), "check"],
+        ):
+            multiple = run_make(make, arguments, caller, environment)
+            if multiple.returncode == 0 or "repository Makefile must be loaded alone" not in multiple.stderr:
+                raise RuntimeError("multiple loaded Makefiles must fail closed")
+
+        for target in ("check", "xcode-test"):
+            replacement = run_make(
+                make,
+                ["-f", repository_makefile, "-f", str(replacement_makefile), target],
+                caller,
+                environment,
+            )
+            if replacement.returncode == 0 or "BYPASSED" in replacement.stdout:
+                raise RuntimeError(f"later recipes must not replace repository verification: {target}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Preserve absolute iHeartRating Makefile roots that contain spaces and fail closed when untrusted Makefile inputs could replace verification recipes.

## Baseline

Master `4d13bc857c3fe32c12cb37e268d913ad2f70cb63` passed the normal static iOS baseline, while absolute Makefile paths containing spaces failed under GNU Make 4.2 and 4.4 before the checker ran. The repository already documented location-independent Make gates and protected `ROOT` from command-line overrides, but the baseline only asserted the vulnerable expression and did not reject preloaded, overridden, additional, or later replacement Makefiles.

## Improvements

- Derive the checkout root from the single loaded repository Makefile while preserving spaces and `override` semantics.
- Reject nonempty `MAKEFILES`, command-line `MAKEFILE_LIST`, multiple loaded Makefiles, and later recipes that attempt to replace `check` or `xcode-test`.
- Add a recursive-safe regression from an external directory against a copied checkout whose absolute path contains spaces, including all ambiguity and replacement attacks.
- Strengthen the static baseline to require the helper, fail-closed Make authority contract, synchronized guidance, and completed plan evidence.
- Preserve the existing `xcode-test` behavior and leave Swift, tests, Xcode projects, podspecs, build script, package boundary, and workflow unchanged.

## Validation

- `git diff --check`
- Python compilation of the baseline and recursive helper.
- GNU Make 4.2 and 4.4: `check`, `lint`, `test`, and `build`; each recursively passed from a copied space-containing checkout.
- Hostile `ROOT=/tmp/hostile-root` checks passed under both Make versions.
- Preloaded `MAKEFILES`, overridden `MAKEFILE_LIST`, repository Makefile ordering in both directions, and later `check`/`xcode-test` recipe replacements failed closed under both Make versions.
- The old root derivation negative control failed the strengthened baseline.
- Two fresh exact-head clones passed strict Git integrity; working, staged, exact-tree, head-ancestry, and two-commit base-to-head gitleaks scans found no secrets.
- Hosted macOS `make check` and `make xcode-test` plus CodeQL are required at exact head `c464302ff306bc8f7916fb7de2e234e801816a51`.

## Risk

Low. This changes verification path resolution and Make authority contracts only. The recursive regression adds a small amount of gate runtime. Executable Apple-platform behavior remains covered by the unchanged hosted Xcode gate.

## Follow-Ups

No code follow-up is required. Revert commits `c464302ff306bc8f7916fb7de2e234e801816a51` and `a07451cb7fcd369d4941f4e91398c0208f79e73f` if the Make authority hardening needs to be rolled back.